### PR TITLE
Issue #177: Command for selfmute

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,7 +19,7 @@ from discord.ext import commands, tasks
 from src.sheets.events import getEvents
 from src.sheets.censor import getCensor
 from src.sheets.sheets import sendVariables, getVariables
-from src.forums.forums import openBrowser
+# from src.forums.forums import openBrowser
 from src.wiki.stylist import prettifyTemplates
 from src.wiki.tournaments import getTournamentList
 from src.wiki.wiki import implementCommand
@@ -1283,28 +1283,15 @@ async def unexalt(ctx, user):
 async def mute(ctx, user:discord.Member, *args):
     """Mutes a user."""
     time = " ".join(args)
-    # if user.id in PI_BOT_IDS:
-    #     return await ctx.send("Hey! You can't mute me!!")
-    # if time == None:
-    #     return await ctx.send("You need to specify a length that this used will be muted. Examples are: `1 day`, `2 months, 1 day`, or `indef` (aka, forever).")
-    # role = discord.utils.get(user.guild.roles, name="Muted")
-    # parsed = "indef"
-    # if time != "indef":
-    #     parsed = dateparser.parse(time, settings={"PREFER_DATES_FROM": "future"})
-    #     if parsed == None:
-    #         return await ctx.send("Sorry, but I don't understand that length of time.")
-    #     CRON_LIST.append({"date": parsed, "do": f"unmute {user.id}"})
-    # await user.add_roles(role)
-    # await ctx.send(f"Successfully muted {user.mention} until `{str(parsed)} " + f"{timePackage.tzname[timePackage.daylight]}" + "`.")
     await _mute(ctx, user, time)
 
 @bot.command()
 async def selfmute(ctx, *args):
     user = ctx.message.author
     time = " ".join(args)
-    _mute(ctx, user, time)
+    await _mute(ctx, user, time)
 
-async def _mute(ctx, user:discordMember, time: str):
+async def _mute(ctx, user:discord.Member, time: str):
     if user.id in PI_BOT_IDS:
         return await ctx.send("Hey! You can't mute me!!")
     if time == None:

--- a/bot.py
+++ b/bot.py
@@ -79,7 +79,8 @@ async def isAdmin(ctx):
 ##############
 PI_BOT_IDS = [
     723767075427844106,
-    743254543952904197
+    743254543952904197,
+    637519324072116247
 ]
 RULES_CHANNEL_ID = 737087680269123606
 WELCOME_CHANNEL_ID = 743253216921387088
@@ -1282,6 +1283,28 @@ async def unexalt(ctx, user):
 async def mute(ctx, user:discord.Member, *args):
     """Mutes a user."""
     time = " ".join(args)
+    # if user.id in PI_BOT_IDS:
+    #     return await ctx.send("Hey! You can't mute me!!")
+    # if time == None:
+    #     return await ctx.send("You need to specify a length that this used will be muted. Examples are: `1 day`, `2 months, 1 day`, or `indef` (aka, forever).")
+    # role = discord.utils.get(user.guild.roles, name="Muted")
+    # parsed = "indef"
+    # if time != "indef":
+    #     parsed = dateparser.parse(time, settings={"PREFER_DATES_FROM": "future"})
+    #     if parsed == None:
+    #         return await ctx.send("Sorry, but I don't understand that length of time.")
+    #     CRON_LIST.append({"date": parsed, "do": f"unmute {user.id}"})
+    # await user.add_roles(role)
+    # await ctx.send(f"Successfully muted {user.mention} until `{str(parsed)} " + f"{timePackage.tzname[timePackage.daylight]}" + "`.")
+    await _mute(ctx, user, time)
+
+@bot.command()
+async def selfmute(ctx, *args):
+    user = ctx.message.author
+    time = " ".join(args)
+    _mute(ctx, user, time)
+
+async def _mute(ctx, user:discordMember, time: str):
     if user.id in PI_BOT_IDS:
         return await ctx.send("Hey! You can't mute me!!")
     if time == None:

--- a/bot.py
+++ b/bot.py
@@ -19,7 +19,7 @@ from discord.ext import commands, tasks
 from src.sheets.events import getEvents
 from src.sheets.censor import getCensor
 from src.sheets.sheets import sendVariables, getVariables
-# from src.forums.forums import openBrowser
+from src.forums.forums import openBrowser
 from src.wiki.stylist import prettifyTemplates
 from src.wiki.tournaments import getTournamentList
 from src.wiki.wiki import implementCommand
@@ -1281,17 +1281,38 @@ async def unexalt(ctx, user):
 @bot.command()
 @commands.check(isStaff)
 async def mute(ctx, user:discord.Member, *args):
-    """Mutes a user."""
+    """
+    Mutes a user.
+
+    :param user: User to be muted.
+    :type user: discord.Member
+    :param *args: The time to mute the user for.
+    :type *args: str
+    """
     time = " ".join(args)
-    await _mute(ctx, user, time)
+    await __mute(ctx, user, time)
 
 @bot.command()
 async def selfmute(ctx, *args):
+    """
+    Self mutes the user that invokes the command.
+
+    :param *args: The time to mute the user for.
+    :type *args: str
+    """
     user = ctx.message.author
     time = " ".join(args)
-    await _mute(ctx, user, time)
+    await __mute(ctx, user, time)
 
-async def _mute(ctx, user:discord.Member, time: str):
+async def __mute(ctx, user:discord.Member, time: str):
+    """
+    Helper function for muting commands.
+
+    :param user: User to be muted.
+    :type user: discord.Member
+    :param time: The time to mute the user for.
+    :type time: str
+    """
     if user.id in PI_BOT_IDS:
         return await ctx.send("Hey! You can't mute me!!")
     if time == None:

--- a/bot.py
+++ b/bot.py
@@ -1290,7 +1290,7 @@ async def mute(ctx, user:discord.Member, *args):
     :type *args: str
     """
     time = " ".join(args)
-    await __mute(ctx, user, time)
+    await _mute(ctx, user, time)
 
 @bot.command()
 async def selfmute(ctx, *args):
@@ -1302,9 +1302,9 @@ async def selfmute(ctx, *args):
     """
     user = ctx.message.author
     time = " ".join(args)
-    await __mute(ctx, user, time)
+    await _mute(ctx, user, time)
 
-async def __mute(ctx, user:discord.Member, time: str):
+async def _mute(ctx, user:discord.Member, time: str):
     """
     Helper function for muting commands.
 

--- a/commandinfo.py
+++ b/commandinfo.py
@@ -182,6 +182,30 @@ COMMAND_INFO = [
         ]
     },
     {
+        "name": "selfmute",
+        "description": "Mutes the user who calls it",
+        "aliases": [],
+        "parameters": [
+            {
+                "name": "time",
+                "description": "the length of the mute"
+            }
+        ],
+        "usage":[
+            {
+                "cmd": "!selfmute \"1 day\"",
+                "result": "mutes the user who sends command for 1 day"
+            },
+            {
+                "cmd": "!selfmute \"indef\"",
+                "result": "mutes the user who sends command for an indefinite amount of time"
+            }
+        ],
+        "access":[
+            "Member"
+        ]
+    },
+    {
         "name": "unmute",
         "description": "unmutes a user",
         "aliases": [],


### PR DESCRIPTION
Uses the same code from mute command. Moved mute code to a helper function for simplicity. Closes #177 .