### PR TITLE
Issue #61: Changed !list to show a quick list and !list all to show a full list of commands.

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -29,7 +29,7 @@ from info import getAbout
 from doggo import getDoggo, getShiba
 from bear import getBearMessage
 from embed import assembleEmbed
-from commands import getList, getHelp
+from commands import getList, getQuickList, getHelp
 from lists import getStateList
 
 load_dotenv()
@@ -791,7 +791,10 @@ async def me(ctx, *args):
 @bot.command()
 async def list(ctx, cmd:str=False):
     """Lists all of the commands a user may access."""
-    if cmd == False or cmd == "commands":
+    if cmd == False: # for quick list of commands
+        ls = await getQuickList(ctx)
+        await ctx.send(embed=ls)
+    if cmd == "all" or cmd == "commands":
         ls = await getList(ctx)
         await ctx.send(embed=ls)
     elif cmd == "states":
@@ -953,7 +956,7 @@ async def events(ctx, *args):
     if type(EVENT_INFO) == int:
         # When the bot starts up, EVENT_INFO is initialized to 0 before receiving the data from the sheet a few seconds later. This lets the user know this.
         return await ctx.send("Apologies... refreshing data currently. Try again in a few seconds.")
-    
+
     for i in range(7, 1, -1):
         # Supports adding 7-word to 2-word long events
         multiWordEvents += [e['eventName'] for e in eventInfo if len(e['eventName'].split(" ")) == i]

--- a/commandinfo.py
+++ b/commandinfo.py
@@ -12,7 +12,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "getuserid",
@@ -36,7 +37,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "about",
@@ -51,7 +53,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "fish",
@@ -66,7 +69,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "nofish",
@@ -81,7 +85,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "help",
@@ -105,7 +110,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "exalt",
@@ -127,7 +133,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "unexalt",
@@ -149,7 +156,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "mute",
@@ -179,7 +187,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "unmute",
@@ -201,7 +210,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "ban",
@@ -235,7 +245,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "unban",
@@ -257,7 +268,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "states",
@@ -289,7 +301,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "nuke",
@@ -311,7 +324,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "division",
@@ -335,7 +349,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "dogbomb",
@@ -355,7 +370,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "shibabomb",
@@ -375,7 +391,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "events",
@@ -407,7 +424,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "kick",
@@ -429,7 +447,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "prepembed",
@@ -495,7 +514,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "report",
@@ -515,7 +535,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "games",
@@ -530,7 +551,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "ping",
@@ -566,7 +588,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "pronouns",
@@ -590,7 +613,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "wiki",
@@ -642,7 +666,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "profile",
@@ -666,7 +691,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "list",
@@ -694,7 +720,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "count",
@@ -707,7 +734,8 @@ COMMAND_INFO = [
         }],
         "access": [
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "wikipedia",
@@ -743,7 +771,8 @@ COMMAND_INFO = [
         ],
         "access": [
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "hello",
@@ -756,7 +785,8 @@ COMMAND_INFO = [
         }],
         "access": [
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "refresh",
@@ -771,7 +801,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "me",
@@ -791,7 +822,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "dnd",
@@ -806,7 +838,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "slowmode",
@@ -836,7 +869,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "school",
@@ -864,7 +898,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "invite",
@@ -877,7 +912,8 @@ COMMAND_INFO = [
         }],
         "access": [
             "Member"
-        ]
+        ],
+        "inQuickList": True
     },
     {
         "name": "lock",
@@ -892,7 +928,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "unlock",
@@ -907,7 +944,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "clrreact",
@@ -937,7 +975,8 @@ COMMAND_INFO = [
             "Administrator",
             "Global Moderator",
             "Wiki/Gallery Moderator"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "obb",
@@ -950,7 +989,8 @@ COMMAND_INFO = [
         }],
         "access": [
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "exchange",
@@ -963,7 +1003,8 @@ COMMAND_INFO = [
         }],
         "access": [
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "gallery",
@@ -976,7 +1017,8 @@ COMMAND_INFO = [
         }],
         "access": [
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "getemojiid",
@@ -996,6 +1038,7 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     }
 ]

--- a/commands.py
+++ b/commands.py
@@ -6,22 +6,39 @@ from commandinfo import COMMAND_INFO
 
 async def getList(ctx):
     """Gets the list of commands a user can access."""
-    availableCommands = []
-    member = ctx.message.author
-    for command in COMMAND_INFO:
-        access = command['access']
-        for roleName in access:
-            role = discord.utils.get(member.guild.roles, name=roleName)
-            if role in member.roles:
-                availableCommands.append({
-                    'name': command['name'],
-                    'description': command['description']
-                })
-                break
+    availableCommands = await __generateList(ctx.message.author, False)
     return assembleEmbed(
-        title=f"Available Commands for {ctx.message.author}",
+        title=f"Full List of Available Commands for {ctx.message.author}",
         desc="\n".join([f"`{c['name']}` - {c['description']}" for c in availableCommands])
     )
+
+async def getQuickList(ctx):
+    """Gets the quick list of commands a user can access."""
+    availableCommands = await __generateList(ctx.message.author, True)
+    return assembleEmbed(
+        title=f"Quick List of Available Commands for {ctx.message.author}",
+        desc="To view full list, please do !list all",
+        fields=[{
+            "name": "Commands",
+            "value": "\n".join([f"`{c['name']}` - {c['description']}" for c in availableCommands]),
+            "inline": False
+        }]
+    )
+
+async def __generateList(member: discord.Member, isQuick = False):
+    availableCommands = []
+    for command in COMMAND_INFO:
+        if not isQuick or command['inQuickList']:
+            access = command['access']
+            for roleName in access:
+                role = discord.utils.get(member.guild.roles, name=roleName)
+                if role in member.roles:
+                    availableCommands.append({
+                        'name': command['name'],
+                        'description': command['description']
+                    })
+                    break
+    return availableCommands
 
 async def getHelp(ctx, cmd):
     """Gets the help embed for a command."""

--- a/commands.py
+++ b/commands.py
@@ -4,27 +4,6 @@ import discord
 from embed import assembleEmbed
 from commandinfo import COMMAND_INFO
 
-async def getList(ctx):
-    """Gets the list of commands a user can access."""
-    availableCommands = await _generateList(ctx.message.author, False)
-    return assembleEmbed(
-        title=f"Full List of Available Commands for {ctx.message.author}",
-        desc="\n".join([f"`{c['name']}` - {c['description']}" for c in availableCommands])
-    )
-
-async def getQuickList(ctx):
-    """Gets the quick list of commands a user can access."""
-    availableCommands = await _generateList(ctx.message.author, True)
-    return assembleEmbed(
-        title=f"Quick List of Available Commands for {ctx.message.author}",
-        desc="To view full list, please do !list all",
-        fields=[{
-            "name": "Commands",
-            "value": "\n".join([f"`{c['name']}` - {c['description']}" for c in availableCommands]),
-            "inline": False
-        }]
-    )
-
 async def _generateList(member: discord.Member, isQuick = False):
     """
     Generates a list of available commands for a user.
@@ -35,7 +14,7 @@ async def _generateList(member: discord.Member, isQuick = False):
     :type isQuick: bool, optional
 
     :return availableCommands: A list of commands to be displayed.
-    :type availableCommands: List[Dictionary]
+    :rtype availableCommands: List[Dictionary]
     """
     availableCommands = []
     for command in COMMAND_INFO:
@@ -50,6 +29,27 @@ async def _generateList(member: discord.Member, isQuick = False):
                     })
                     break
     return availableCommands
+
+async def getList(ctx):
+    """Gets the list of commands a user can access."""
+    availableCommands = await _generateList(ctx.message.author, False)
+    return assembleEmbed(
+        title=f"Full List of Available Commands for {ctx.message.author}",
+        desc="\n".join([f"`{c['name']}` - {c['description']}" for c in availableCommands])
+    )
+
+async def getQuickList(ctx):
+    """Gets the quick list of commands a user can access."""
+    availableCommands = await _generateList(ctx.message.author, True)
+    return assembleEmbed(
+        title=f"Quick List of Available Commands for {ctx.message.author}",
+        desc="To view full list, please type `!list all`.",
+        fields=[{
+            "name": "Commands",
+            "value": "\n".join([f"`{c['name']}` - {c['description']}" for c in availableCommands]),
+            "inline": False
+        }]
+    )
 
 async def getHelp(ctx, cmd):
     """Gets the help embed for a command."""

--- a/commands.py
+++ b/commands.py
@@ -26,6 +26,17 @@ async def getQuickList(ctx):
     )
 
 async def __generateList(member: discord.Member, isQuick = False):
+    """
+    Generates a list of available commands for a user.
+
+    :param member: The user that wants to generate a list of commands
+    :type member: discord.Member
+    :param isQuick: True if quick list should be generated. False if full list should be generated.
+    :type isQuick: bool, optional
+
+    :return availableCommands: A list of commands to be displayed.
+    :type availableCommands: List[Dictionary]
+    """
     availableCommands = []
     for command in COMMAND_INFO:
         if not isQuick or command['inQuickList']:

--- a/commands.py
+++ b/commands.py
@@ -6,7 +6,7 @@ from commandinfo import COMMAND_INFO
 
 async def getList(ctx):
     """Gets the list of commands a user can access."""
-    availableCommands = await __generateList(ctx.message.author, False)
+    availableCommands = await _generateList(ctx.message.author, False)
     return assembleEmbed(
         title=f"Full List of Available Commands for {ctx.message.author}",
         desc="\n".join([f"`{c['name']}` - {c['description']}" for c in availableCommands])
@@ -14,7 +14,7 @@ async def getList(ctx):
 
 async def getQuickList(ctx):
     """Gets the quick list of commands a user can access."""
-    availableCommands = await __generateList(ctx.message.author, True)
+    availableCommands = await _generateList(ctx.message.author, True)
     return assembleEmbed(
         title=f"Quick List of Available Commands for {ctx.message.author}",
         desc="To view full list, please do !list all",
@@ -25,7 +25,7 @@ async def getQuickList(ctx):
         }]
     )
 
-async def __generateList(member: discord.Member, isQuick = False):
+async def _generateList(member: discord.Member, isQuick = False):
     """
     Generates a list of available commands for a user.
 


### PR DESCRIPTION
Created new functions to help implement the quick list. Closes #61.

**THINGS TO NOTE**
The structure of `COMMAND_INFO` has been modified to include an `inQuickList` property on each command. This quickly identifies which commands to show to the user. I've set it to a few commands that might be appropriate for new users to get started with. Feel free to change these commands to whatever you want.
I also didn't set any of the mod-exclusive commands to `True` (I don't know how useful it'll be for mods given that they should already be familiar), but as I said, feel free to change this.