### PR TITLE
Issue #176: !comfirm confirms first, then deletes messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,7 +19,7 @@ from discord.ext import commands, tasks
 from src.sheets.events import getEvents
 from src.sheets.censor import getCensor
 from src.sheets.sheets import sendVariables, getVariables
-from src.forums.forums import openBrowser
+# from src.forums.forums import openBrowser
 from src.wiki.stylist import prettifyTemplates
 from src.wiki.tournaments import getTournamentList
 from src.wiki.wiki import implementCommand
@@ -1435,6 +1435,7 @@ async def pronouns(ctx, *args):
 @commands.check(isLauncher)
 async def confirm(ctx, *args: discord.Member):
     """Allows a staff member to confirm a user."""
+    msgs = []
     for i, member in enumerate(args):
         beforeMessage = None
         f = 0
@@ -1443,10 +1444,13 @@ async def confirm(ctx, *args: discord.Member):
         await member.remove_roles(role1)
         await member.add_roles(role2)
         message = await ctx.send(f"Alrighty, confirmed {member.mention}. Welcome to the server! :tada:")
-        await asyncio.sleep(3)
+        msgs.append(message)
+
+    await asyncio.sleep(3)
+    for i, m in enumerate(msgs):
         if not i:
             await ctx.message.delete()
-        await message.delete()
+        await m.delete()
 
     for i, member in enumerate(args):
         async for message in ctx.message.channel.history(oldest_first=True):

--- a/bot.py
+++ b/bot.py
@@ -19,7 +19,7 @@ from discord.ext import commands, tasks
 from src.sheets.events import getEvents
 from src.sheets.censor import getCensor
 from src.sheets.sheets import sendVariables, getVariables
-# from src.forums.forums import openBrowser
+from src.forums.forums import openBrowser
 from src.wiki.stylist import prettifyTemplates
 from src.wiki.tournaments import getTournamentList
 from src.wiki.wiki import implementCommand

--- a/bot.py
+++ b/bot.py
@@ -1438,6 +1438,17 @@ async def confirm(ctx, *args: discord.Member):
     for i, member in enumerate(args):
         beforeMessage = None
         f = 0
+        role1 = discord.utils.get(member.guild.roles, name="Unconfirmed")
+        role2 = discord.utils.get(member.guild.roles, name="Member")
+        await member.remove_roles(role1)
+        await member.add_roles(role2)
+        message = await ctx.send(f"Alrighty, confirmed {member.mention}. Welcome to the server! :tada:")
+        await asyncio.sleep(3)
+        if not i:
+            await ctx.message.delete()
+        await message.delete()
+
+    for i, member in enumerate(args):
         async for message in ctx.message.channel.history(oldest_first=True):
             # Delete any messages sent by Pi-Bot where message before is by member
             if f > 0:
@@ -1450,15 +1461,6 @@ async def confirm(ctx, *args: discord.Member):
 
             beforeMessage = message
             f += 1
-        role1 = discord.utils.get(member.guild.roles, name="Unconfirmed")
-        role2 = discord.utils.get(member.guild.roles, name="Member")
-        await member.remove_roles(role1)
-        await member.add_roles(role2)
-        message = await ctx.send(f"Alrighty, confirmed {member.mention}. Welcome to the server! :tada:")
-        await asyncio.sleep(3)
-        if not i:
-            await ctx.message.delete()
-        await message.delete()
 
 @bot.command()
 async def nuke(ctx, count):


### PR DESCRIPTION
As mentioned in title. Confirmation works as intended. Wasn't able to test deletion of unconfirmed users' messages. Closes #176.