### PR TITLE
Issue #196: Fixed !list

### DIFF
--- a/commandinfo.py
+++ b/commandinfo.py
@@ -212,7 +212,8 @@ COMMAND_INFO = [
         ],
         "access":[
             "Member"
-        ]
+        ],
+        "inQuickList": False
     },
     {
         "name": "unmute",


### PR DESCRIPTION
`!list` command no longer errors. Was due to the `selfmute` command not having the inQuickList key in commandinfo. Closes #196.