### PR TITLE
Issue #305: Added channel whitelist/blacklist for commands.

### DIFF
--- a/blacklistexception.py
+++ b/blacklistexception.py
@@ -1,0 +1,5 @@
+import discord.ext.commands as commands
+class BlacklistException(commands.CommandError):
+    def __init__(self, channel, *args, **kwargs):
+        self.channel = channel
+        super().__init__(*args, **kwargs)

--- a/bot.py
+++ b/bot.py
@@ -182,7 +182,7 @@ def notBlacklistedChannel(blacklist):
         for c in blacklist:
             if channel == discord.utils.get(server.text_channels, name=c):
                 # print("DENIED")
-                raise CommandNotAllowedInChannel(channel)
+                raise CommandNotAllowedInChannel(channel, "Command was invoked in a blacklisted channel.")
         return True
     
     return commands.check(predicate)
@@ -195,7 +195,7 @@ def isWhitelistedChannel(whitelist):
         for c in whitelist:
             if channel == discord.utils.get(server.text_channels, name=c):
                 return True
-        raise CommandNotAllowedInChannel(channel)
+        raise CommandNotAllowedInChannel(channel, "Command was invoked in a non-whitelisted channel.")
     
     return commands.check(predicate)
 

--- a/bot.py
+++ b/bot.py
@@ -173,13 +173,17 @@ async def isAdmin(ctx):
     aRole = discord.utils.get(member.guild.roles, name=ROLE_AD)
     if aRole in member.roles or member.id == 715048392408956950: return True
 
-async def notBlacklistedChannels(ctx, blacklist):
-    """Checks if command was invoked in specified blacklisted channel."""
-    channel = ctx.message.channel
-    for channel in blacklist:
-        if channel.id == discord.utils.get(server.text_channels, name=channel).id:
-            return False
-    return True
+def notBlacklistedChannels(blacklist):
+    async def predicate(ctx):
+        """Checks if command was invoked in specified blacklisted channel."""
+        channel = ctx.message.channel
+        for channel in blacklist:
+            if channel.id == discord.utils.get(server.text_channels, name=channel).id:
+                print("DENIED")
+                return False
+        return True
+    
+    return commands.check(predicate)
 
 ##############
 # CONSTANTS
@@ -1638,6 +1642,7 @@ async def help(ctx, command:str=None):
     await ctx.send(embed=hlp)
 
 @bot.command(aliases=["feedbear"])
+@commands.check(notBlacklistedChannels(blacklist=["welcome"]))
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow

--- a/bot.py
+++ b/bot.py
@@ -181,7 +181,6 @@ def notBlacklistedChannel(blacklist):
         server = bot.get_guild(SERVER_ID)
         for c in blacklist:
             if channel == discord.utils.get(server.text_channels, name=c):
-                # print("DENIED")
                 raise CommandNotAllowedInChannel(channel, "Command was invoked in a blacklisted channel.")
         return True
     

--- a/bot.py
+++ b/bot.py
@@ -174,9 +174,9 @@ async def isAdmin(ctx):
     aRole = discord.utils.get(member.guild.roles, name=ROLE_AD)
     if aRole in member.roles or member.id == 715048392408956950: return True
 
-def notBlacklistedChannels(blacklist):
+def notBlacklistedChannel(blacklist):
+    """Given a string array blacklist, check if command was not invoked in specified blacklist channels."""
     async def predicate(ctx):
-        """Checks if command was invoked in specified blacklisted channel."""
         channel = ctx.message.channel
         server = bot.get_guild(SERVER_ID)
         for c in blacklist:
@@ -188,7 +188,7 @@ def notBlacklistedChannels(blacklist):
     return commands.check(predicate)
     
 def isWhitelistedChannel(whitelist):
-    """Given a string array whitelist, check if  command was invoked in specified whitelisted channel."""
+    """Given a string array whitelist, check if command was invoked in specified whitelisted channels."""
     async def predicate(ctx):
         channel = ctx.message.channel
         server = bot.get_guild(SERVER_ID)
@@ -1656,7 +1656,7 @@ async def help(ctx, command:str=None):
     await ctx.send(embed=hlp)
 
 @bot.command(aliases=["feedbear"])
-@notBlacklistedChannels(blacklist=[CHANNEL_WELCOME, CHANNEL_BOTSPAM])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME, CHANNEL_BOTSPAM])
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow

--- a/bot.py
+++ b/bot.py
@@ -36,7 +36,7 @@ from embed import assembleEmbed
 from commands import getList, getQuickList, getHelp
 from lists import getStateList
 import xkcd as xkcd_module # not to interfere with xkcd method
-from blacklistexception import BlacklistException
+from commanderrors import CommandNotAllowedInChannel
 
 load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')
@@ -182,7 +182,7 @@ def notBlacklistedChannels(blacklist):
         for c in blacklist:
             if channel == discord.utils.get(server.text_channels, name=c):
                 # print("DENIED")
-                raise BlacklistException(channel)
+                raise CommandNotAllowedInChannel(channel)
         return True
     
     return commands.check(predicate)
@@ -2649,7 +2649,7 @@ async def on_command_error(ctx, error):
         return await ctx.send("Uh... this channel can only be run in a NSFW channel... sorry to disappoint.")
 
     # Command errors
-    if isinstance(error, BlacklistException):
+    if isinstance(error, CommandNotAllowedInChannel):
         return await ctx.send(f"You are not allowed to use this command in {error.channel.mention}.")
     if isinstance(error, discord.ext.commands.ConversionError):
         return await ctx.send("Oops, there was a bot error here, sorry about that.")
@@ -2662,9 +2662,6 @@ async def on_command_error(ctx, error):
     if isinstance(error, discord.ext.commands.DisabledCommand):
         return await ctx.send("Sorry, but this command is disabled.")
     if isinstance(error, discord.ext.commands.CommandInvokeError):
-        # if isinstance(error.original, BlacklistException):
-        #     return await ctx.send("You are not allowed to run that command here smh")
-        # else:
         return await ctx.send("Sorry, but an error incurred when the command was invoked.")
     if isinstance(error, discord.ext.commands.CommandOnCooldown):
         return await ctx.send("Slow down buster! This command's on cooldown.")

--- a/bot.py
+++ b/bot.py
@@ -1643,7 +1643,7 @@ async def help(ctx, command:str=None):
     await ctx.send(embed=hlp)
 
 @bot.command(aliases=["feedbear"])
-@commands.check(notBlacklistedChannels(blacklist=["welcome"]))
+@notBlacklistedChannels(blacklist=[CHANNEL_WELCOME])
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow

--- a/bot.py
+++ b/bot.py
@@ -177,9 +177,10 @@ def notBlacklistedChannels(blacklist):
     async def predicate(ctx):
         """Checks if command was invoked in specified blacklisted channel."""
         channel = ctx.message.channel
-        for channel in blacklist:
-            if channel.id == discord.utils.get(server.text_channels, name=channel).id:
-                print("DENIED")
+        server = bot.get_guild(SERVER_ID)
+        for c in blacklist:
+            if channel == discord.utils.get(server.text_channels, name=c):
+                # print("DENIED")
                 return False
         return True
     

--- a/bot.py
+++ b/bot.py
@@ -173,6 +173,14 @@ async def isAdmin(ctx):
     aRole = discord.utils.get(member.guild.roles, name=ROLE_AD)
     if aRole in member.roles or member.id == 715048392408956950: return True
 
+async def notBlacklistedChannels(ctx, blacklist):
+    """Checks if command was invoked in specified blacklisted channel."""
+    channel = ctx.message.channel
+    for channel in blacklist:
+        if channel.id == discord.utils.get(server.text_channels, name=channel).id:
+            return False
+    return True
+
 ##############
 # CONSTANTS
 ##############

--- a/bot.py
+++ b/bot.py
@@ -195,7 +195,7 @@ def isWhitelistedChannel(whitelist):
         for c in whitelist:
             if channel == discord.utils.get(server.text_channels, name=c):
                 return True
-        return raise CommandNotAllowedInChannel(channel)
+        raise CommandNotAllowedInChannel(channel)
     
     return commands.check(predicate)
 

--- a/bot.py
+++ b/bot.py
@@ -763,6 +763,7 @@ async def rand(ctx, a=1, b=10):
     await ctx.send(f"Random number between `{a}` and `{b}`: `{r}`")
 
 @bot.command()
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def magic8ball(ctx):
     msg = await ctx.send("Swishing the magic 8 ball...")
     await ctx.channel.trigger_typing()
@@ -793,6 +794,7 @@ async def magic8ball(ctx):
     await ctx.send(f"**{response}**")
 
 @bot.command()
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def xkcd(ctx, num = None):
     max_num = await xkcd_module.get_max()
     if num == None:
@@ -1389,6 +1391,7 @@ async def pingPM(userID, pinger, pingExp, channel, content, jumpUrl):
     await userToSend.send(embed=embed)
 
 @bot.command(aliases=["doggobomb"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def dogbomb(ctx, member:str=False):
     """Dog bombs someone!"""
     if member == False:
@@ -1398,6 +1401,7 @@ async def dogbomb(ctx, member:str=False):
     await ctx.send(f"{member}, <@{ctx.message.author.id}> dog bombed you!!")
 
 @bot.command()
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def shibabomb(ctx, member:str=False):
     """Shiba bombs a user!"""
     if member == False:
@@ -1656,7 +1660,7 @@ async def help(ctx, command:str=None):
     await ctx.send(embed=hlp)
 
 @bot.command(aliases=["feedbear"])
-@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME, CHANNEL_BOTSPAM])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow
@@ -1678,11 +1682,13 @@ async def fish(ctx):
         return await ctx.send(f":sob:\n:sob:\n:sob:\nAww, bear's fish was accidentally square root'ed. Bear now has {fishNow} fish. \n:sob:\n:sob:\n:sob:")
 
 @bot.command()
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def nofish(ctx):
     """DEPRECATED - Removes all of bear's fish."""
     await ctx.send("`!nofish` no longer exists! Please use `!stealfish` instead.")
 
 @bot.command(aliases=["badbear"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def stealfish(ctx):
     global fishNow
     member = ctx.message.author
@@ -1711,6 +1717,7 @@ async def stealfish(ctx):
         return await ctx.send("You are banned from using `!stealfish` until the next version of Pi-Bot is released.")
 
 @bot.command(aliases=["slap", "trouts", "slaps", "troutslaps"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def trout(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. Not so fast!")
@@ -1721,6 +1728,7 @@ async def trout(ctx, member:str=False):
     await ctx.send("http://gph.is/1URFXN9")
 
 @bot.command(aliases=["givecookie"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def cookie(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1731,11 +1739,13 @@ async def cookie(ctx, member:str=False):
     await ctx.send("http://gph.is/1UOaITh")
 
 @bot.command()
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def treat(ctx):
     await ctx.send("You give bernard one treat!")
     await ctx.send("http://gph.is/11nJAH5")
 
 @bot.command(aliases=["givehershey", "hershey"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def hersheybar(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1746,6 +1756,7 @@ async def hersheybar(ctx, member:str=False):
     await ctx.send("http://gph.is/2rt64CX")
 
 @bot.command(aliases=["giveicecream"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def icecream(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")

--- a/bot.py
+++ b/bot.py
@@ -186,6 +186,18 @@ def notBlacklistedChannels(blacklist):
         return True
     
     return commands.check(predicate)
+    
+def isWhitelistedChannel(whitelist):
+    """Given a string array whitelist, check if  command was invoked in specified whitelisted channel."""
+    async def predicate(ctx):
+        channel = ctx.message.channel
+        server = bot.get_guild(SERVER_ID)
+        for c in whitelist:
+            if channel == discord.utils.get(server.text_channels, name=c):
+                return True
+        return raise CommandNotAllowedInChannel(channel)
+    
+    return commands.check(predicate)
 
 ##############
 # CONSTANTS

--- a/commanderrors.py
+++ b/commanderrors.py
@@ -1,5 +1,5 @@
 import discord.ext.commands as commands
-class BlacklistException(commands.CommandError):
+class CommandNotAllowedInChannel(commands.CommandError):
     def __init__(self, channel, *args, **kwargs):
         self.channel = channel
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
`discord.py` did not have a built-in function to detect the channel a command was invoked, so I implemented my own using the `commands.check()` predicate. I applied the blacklist to all fun commands. I also decided to add a whitelist check so we can regulate for certain commands to be run in a specific channel(s) as well. Closes #305 .