### PR TITLE
Hotfix: bot-spam only commands standardization

### DIFF
--- a/blacklistexception.py
+++ b/blacklistexception.py
@@ -1,0 +1,5 @@
+import discord.ext.commands as commands
+class BlacklistException(commands.CommandError):
+    def __init__(self, channel, *args, **kwargs):
+        self.channel = channel
+        super().__init__(*args, **kwargs)

--- a/bot.py
+++ b/bot.py
@@ -443,7 +443,7 @@ async def pullPrevInfo():
     print("Fetched previous variables.")
 
 @bot.command(aliases=["tc", "tourney", "tournaments"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def tournament(ctx, *args):
     member = ctx.message.author
     newArgs = list(args)
@@ -702,25 +702,25 @@ async def refresh(ctx):
         await ctx.send(":warning: Unsuccessfully refreshed data from sheet.")
 
 @bot.command(aliases=["gci", "cid", "channelid"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def getchannelid(ctx):
     """Gets the channel ID of the current channel."""
     await ctx.send("Hey <@" + str(ctx.message.author.id) + ">! The channel ID is `" + str(ctx.message.channel.id) + "`. :)")
 
 @bot.command(aliases=["gei", "eid"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def getemojiid(ctx, emoji: discord.Emoji):
     """Gets the ID of the given emoji."""
     return await ctx.send(f"{emoji} - `{emoji}`")
 
 @bot.command(aliases=["rid"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def getroleid(ctx, name):
     role = discord.utils.get(ctx.message.author.guild.roles, name=name)
     return await ctx.send(f"`{role.mention}`")
 
 @bot.command(aliases=["ui"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def getuserid(ctx, user=None):
     """Gets the user ID of the caller or another user."""
     if user == None:
@@ -740,7 +740,7 @@ async def userfromid(ctx, iden:int):
     await ctx.send(user.mention)
 
 @bot.command(aliases=["hi"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def hello(ctx):
     """Simply says hello. Used for testing the bot."""
     await ctx.send("Well, hello there.")
@@ -828,7 +828,7 @@ async def rule(ctx, num):
     return await ctx.send(f"**Rule {num}:**\n> {rule}")
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def coach(ctx):
     """Gives an account the coach role."""
     await ctx.send("Giving you the Coach role...")
@@ -858,7 +858,7 @@ async def slowmode(ctx, arg:int=None):
             await ctx.send(f"Removed slowmode.")
 
 @bot.command(aliases=["state"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def states(ctx, *args):
     """Assigns someone with specific states."""
     newArgs = [str(arg).lower() for arg in args]
@@ -951,7 +951,7 @@ async def states(ctx, *args):
     await ctx.send(stateRes)
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def games(ctx):
     """Removes or adds someone to the games channel."""
     jbcObj = discord.utils.get(ctx.message.author.guild.text_channels, name=CHANNEL_GAMES)
@@ -1040,7 +1040,7 @@ async def unlock(ctx):
     await ctx.send("Unlocked the channel to Member access. Please check if permissions need to be synced.")
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def info(ctx):
     """Gets information about the Discord server."""
     server = ctx.message.guild
@@ -1204,7 +1204,7 @@ async def autoReport(reason, color, message):
     await message.add_reaction("\U0000274C")
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def graphpage(ctx, title, tempFormat, tableIndex, div, placeCol=0):
     temp = tempFormat.lower() in ["y", "yes", "true"]
     await ctx.send(
@@ -1240,7 +1240,7 @@ async def graphpage(ctx, title, tempFormat, tableIndex, div, placeCol=0):
     return await ctx.send("Attempted to graph.")
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def graphscilympiad(ctx, url, title):
     points = await getPoints(url)
     await _graph(points, title, "graph1.svg")
@@ -1262,7 +1262,7 @@ async def _graph(points, graph_title, title):
     await asyncio.sleep(2)
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def resultstemplate(ctx, url):
     if url.find("scilympiad.com") == -1:
         return await ctx.send("The URL must be a Scilympiad results link.")
@@ -1274,7 +1274,7 @@ async def resultstemplate(ctx, url):
     await ctx.send(file=file)
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def ping(ctx, command=None, *args):
     """Controls Pi-Bot's ping interface."""
     if command is None:
@@ -1373,7 +1373,7 @@ async def ping(ctx, command=None, *args):
         return await ctx.send("Sorry, I can't find that command.")
 
 @bot.command(aliases=["donotdisturb"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def dnd(ctx):
     member = ctx.message.author.id
     if any([True for u in PING_INFO if u['id'] == member]):
@@ -1442,7 +1442,7 @@ async def me(ctx, *args):
         await ctx.send(f"*{ctx.message.author.mention} " + " ".join(arg for arg in args) + "*")
 
 @bot.command(aliases=["list"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def list_command(ctx, cmd:str=False):
     """Lists all of the commands a user may access."""
     if cmd == False: # for quick list of commands
@@ -1471,7 +1471,7 @@ async def list_command(ctx, cmd:str=False):
         await ctx.send(embed=list)
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def school(ctx, title, state):
     lists = await getSchoolListing(title, state)
     fields = []
@@ -1593,7 +1593,7 @@ async def prepembed(ctx, channel:discord.TextChannel, *, jsonInput):
     await channel.send(embed=embed)
 
 @bot.command(aliases=["event"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def events(ctx, *args):
     """Adds or removes event roles from a user."""
     if len(args) < 1:
@@ -1669,7 +1669,7 @@ async def getWords():
     CENSORED_WORDS = getCensor()
 
 @bot.command(aliases=["man"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def help(ctx, command:str=None):
     """Allows a user to request help for a command."""
     if command == None:
@@ -1687,7 +1687,7 @@ async def help(ctx, command:str=None):
 
 @bot.command(aliases=["feedbear"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow
@@ -1710,14 +1710,14 @@ async def fish(ctx):
 
 @bot.command()
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def nofish(ctx):
     """DEPRECATED - Removes all of bear's fish."""
     await ctx.send("`!nofish` no longer exists! Please use `!stealfish` instead.")
 
 @bot.command(aliases=["badbear"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def stealfish(ctx):
     global fishNow
     member = ctx.message.author
@@ -1747,7 +1747,7 @@ async def stealfish(ctx):
 
 @bot.command(aliases=["slap", "trouts", "slaps", "troutslaps"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def trout(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. Not so fast!")
@@ -1759,7 +1759,7 @@ async def trout(ctx, member:str=False):
 
 @bot.command(aliases=["givecookie"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def cookie(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1771,14 +1771,14 @@ async def cookie(ctx, member:str=False):
 
 @bot.command()
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def treat(ctx):
     await ctx.send("You give bernard one treat!")
     await ctx.send("http://gph.is/11nJAH5")
 
 @bot.command(aliases=["givehershey", "hershey"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def hersheybar(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1790,7 +1790,7 @@ async def hersheybar(ctx, member:str=False):
 
 @bot.command(aliases=["giveicecream"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def icecream(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1807,7 +1807,7 @@ async def sanitizeMention(member):
     return True
 
 @bot.command(aliases=["div"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def division(ctx, div):
     if div.lower() == "a":
         res = await assignDiv(ctx, "Division A")
@@ -1843,7 +1843,7 @@ async def assignDiv(ctx, div):
     return True
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def alumni(ctx):
     """Removes or adds the alumni role from a user."""
     member = ctx.message.author
@@ -1970,7 +1970,7 @@ async def latex(ctx, *args):
     await ctx.send(r"https://latex.codecogs.com/png.latex?\dpi{150}{\color{Gray}" + newArgs + "}")
 
 @bot.command(aliases=["membercount"])
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def count(ctx):
     guild = ctx.message.author.guild
     await ctx.send(f"Currently, there are `{len(guild.members)}` members in the server.")
@@ -2012,7 +2012,7 @@ async def mute(ctx, user:discord.Member, *args):
     await _mute(ctx, user, time)
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def selfmute(ctx, *args):
     """
     Self mutes the user that invokes the command.
@@ -2097,7 +2097,7 @@ async def unban(ctx, id:int=0):
     await ctx.channel.send(f"Inverse ban hammer applied, user unbanned. Please remember that I cannot force them to re-join the server, they must join themselves.")
 
 @bot.command()
-@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
+@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def pronouns(ctx, *args):
     """Assigns or removes pronoun roles from a user."""
     member = ctx.message.author

--- a/bot.py
+++ b/bot.py
@@ -454,6 +454,7 @@ async def pullPrevInfo():
     print("Fetched previous variables.")
 
 @bot.command(aliases=["tc", "tourney", "tournaments"])
+@isChannelBotSpam()
 async def tournament(ctx, *args):
     member = ctx.message.author
     newArgs = list(args)

--- a/bot.py
+++ b/bot.py
@@ -173,13 +173,17 @@ async def isAdmin(ctx):
     aRole = discord.utils.get(member.guild.roles, name=ROLE_AD)
     if aRole in member.roles or member.id == 715048392408956950: return True
 
-async def notBlacklistedChannels(ctx, blacklist):
-    """Checks if command was invoked in specified blacklisted channel."""
-    channel = ctx.message.channel
-    for channel in blacklist:
-        if channel.id == discord.utils.get(server.text_channels, name=channel).id:
-            return False
-    return True
+def notBlacklistedChannels(blacklist):
+    async def predicate(ctx):
+        """Checks if command was invoked in specified blacklisted channel."""
+        channel = ctx.message.channel
+        for channel in blacklist:
+            if channel.id == discord.utils.get(server.text_channels, name=channel).id:
+                print("DENIED")
+                return False
+        return True
+    
+    return commands.check(predicate)
 
 ##############
 # CONSTANTS
@@ -1638,6 +1642,7 @@ async def help(ctx, command:str=None):
     await ctx.send(embed=hlp)
 
 @bot.command(aliases=["feedbear"])
+@commands.check(notBlacklistedChannels(blacklist=["welcome"]))
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow

--- a/bot.py
+++ b/bot.py
@@ -203,7 +203,7 @@ def isNotMember():
     async def predicate(ctx):
         member = ctx.message.author
         mrRole = discord.utils.get(member.guild.roles, name=ROLE_MR)
-        return not(mrRole in member.roles)
+        return mrRole != member.roles[-1]
     return commands.check(predicate)
 
 ##############

--- a/bot.py
+++ b/bot.py
@@ -174,9 +174,9 @@ async def isAdmin(ctx):
     aRole = discord.utils.get(member.guild.roles, name=ROLE_AD)
     if aRole in member.roles or member.id == 715048392408956950: return True
 
-def notBlacklistedChannels(blacklist):
+def notBlacklistedChannel(blacklist):
+    """Given a string array blacklist, check if command was not invoked in specified blacklist channels."""
     async def predicate(ctx):
-        """Checks if command was invoked in specified blacklisted channel."""
         channel = ctx.message.channel
         server = bot.get_guild(SERVER_ID)
         for c in blacklist:
@@ -188,7 +188,7 @@ def notBlacklistedChannels(blacklist):
     return commands.check(predicate)
     
 def isWhitelistedChannel(whitelist):
-    """Given a string array whitelist, check if  command was invoked in specified whitelisted channel."""
+    """Given a string array whitelist, check if command was invoked in specified whitelisted channels."""
     async def predicate(ctx):
         channel = ctx.message.channel
         server = bot.get_guild(SERVER_ID)
@@ -1656,7 +1656,7 @@ async def help(ctx, command:str=None):
     await ctx.send(embed=hlp)
 
 @bot.command(aliases=["feedbear"])
-@notBlacklistedChannels(blacklist=[CHANNEL_WELCOME, CHANNEL_BOTSPAM])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME, CHANNEL_BOTSPAM])
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow

--- a/bot.py
+++ b/bot.py
@@ -36,7 +36,7 @@ from embed import assembleEmbed
 from commands import getList, getQuickList, getHelp
 from lists import getStateList
 import xkcd as xkcd_module # not to interfere with xkcd method
-from blacklistexception import BlacklistException
+from commanderrors import CommandNotAllowedInChannel
 
 load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')
@@ -182,7 +182,7 @@ def notBlacklistedChannels(blacklist):
         for c in blacklist:
             if channel == discord.utils.get(server.text_channels, name=c):
                 # print("DENIED")
-                raise BlacklistException(channel)
+                raise CommandNotAllowedInChannel(channel)
         return True
     
     return commands.check(predicate)
@@ -2649,7 +2649,7 @@ async def on_command_error(ctx, error):
         return await ctx.send("Uh... this channel can only be run in a NSFW channel... sorry to disappoint.")
 
     # Command errors
-    if isinstance(error, BlacklistException):
+    if isinstance(error, CommandNotAllowedInChannel):
         return await ctx.send(f"You are not allowed to use this command in {error.channel.mention}.")
     if isinstance(error, discord.ext.commands.ConversionError):
         return await ctx.send("Oops, there was a bot error here, sorry about that.")
@@ -2662,9 +2662,6 @@ async def on_command_error(ctx, error):
     if isinstance(error, discord.ext.commands.DisabledCommand):
         return await ctx.send("Sorry, but this command is disabled.")
     if isinstance(error, discord.ext.commands.CommandInvokeError):
-        # if isinstance(error.original, BlacklistException):
-        #     return await ctx.send("You are not allowed to run that command here smh")
-        # else:
         return await ctx.send("Sorry, but an error incurred when the command was invoked.")
     if isinstance(error, discord.ext.commands.CommandOnCooldown):
         return await ctx.send("Slow down buster! This command's on cooldown.")

--- a/bot.py
+++ b/bot.py
@@ -1643,7 +1643,7 @@ async def help(ctx, command:str=None):
     await ctx.send(embed=hlp)
 
 @bot.command(aliases=["feedbear"])
-@commands.check(notBlacklistedChannels(blacklist=["welcome"]))
+@notBlacklistedChannels(blacklist=[CHANNEL_WELCOME])
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow

--- a/bot.py
+++ b/bot.py
@@ -713,25 +713,25 @@ async def refresh(ctx):
         await ctx.send(":warning: Unsuccessfully refreshed data from sheet.")
 
 @bot.command(aliases=["gci", "cid", "channelid"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def getchannelid(ctx):
     """Gets the channel ID of the current channel."""
     await ctx.send("Hey <@" + str(ctx.message.author.id) + ">! The channel ID is `" + str(ctx.message.channel.id) + "`. :)")
 
 @bot.command(aliases=["gei", "eid"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def getemojiid(ctx, emoji: discord.Emoji):
     """Gets the ID of the given emoji."""
     return await ctx.send(f"{emoji} - `{emoji}`")
 
 @bot.command(aliases=["rid"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def getroleid(ctx, name):
     role = discord.utils.get(ctx.message.author.guild.roles, name=name)
     return await ctx.send(f"`{role.mention}`")
 
 @bot.command(aliases=["ui"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def getuserid(ctx, user=None):
     """Gets the user ID of the caller or another user."""
     if user == None:
@@ -751,7 +751,7 @@ async def userfromid(ctx, iden:int):
     await ctx.send(user.mention)
 
 @bot.command(aliases=["hi"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def hello(ctx):
     """Simply says hello. Used for testing the bot."""
     await ctx.send("Well, hello there.")
@@ -839,7 +839,7 @@ async def rule(ctx, num):
     return await ctx.send(f"**Rule {num}:**\n> {rule}")
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def coach(ctx):
     """Gives an account the coach role."""
     await ctx.send("Giving you the Coach role...")
@@ -869,7 +869,7 @@ async def slowmode(ctx, arg:int=None):
             await ctx.send(f"Removed slowmode.")
 
 @bot.command(aliases=["state"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def states(ctx, *args):
     """Assigns someone with specific states."""
     newArgs = [str(arg).lower() for arg in args]
@@ -962,7 +962,7 @@ async def states(ctx, *args):
     await ctx.send(stateRes)
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def games(ctx):
     """Removes or adds someone to the games channel."""
     jbcObj = discord.utils.get(ctx.message.author.guild.text_channels, name=CHANNEL_GAMES)
@@ -1051,7 +1051,7 @@ async def unlock(ctx):
     await ctx.send("Unlocked the channel to Member access. Please check if permissions need to be synced.")
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def info(ctx):
     """Gets information about the Discord server."""
     server = ctx.message.guild
@@ -1215,7 +1215,7 @@ async def autoReport(reason, color, message):
     await message.add_reaction("\U0000274C")
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def graphpage(ctx, title, tempFormat, tableIndex, div, placeCol=0):
     temp = tempFormat.lower() in ["y", "yes", "true"]
     await ctx.send(
@@ -1251,7 +1251,7 @@ async def graphpage(ctx, title, tempFormat, tableIndex, div, placeCol=0):
     return await ctx.send("Attempted to graph.")
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def graphscilympiad(ctx, url, title):
     points = await getPoints(url)
     await _graph(points, title, "graph1.svg")
@@ -1273,7 +1273,7 @@ async def _graph(points, graph_title, title):
     await asyncio.sleep(2)
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def resultstemplate(ctx, url):
     if url.find("scilympiad.com") == -1:
         return await ctx.send("The URL must be a Scilympiad results link.")
@@ -1285,7 +1285,7 @@ async def resultstemplate(ctx, url):
     await ctx.send(file=file)
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def ping(ctx, command=None, *args):
     """Controls Pi-Bot's ping interface."""
     if command is None:
@@ -1384,7 +1384,7 @@ async def ping(ctx, command=None, *args):
         return await ctx.send("Sorry, I can't find that command.")
 
 @bot.command(aliases=["donotdisturb"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def dnd(ctx):
     member = ctx.message.author.id
     if any([True for u in PING_INFO if u['id'] == member]):
@@ -1453,7 +1453,7 @@ async def me(ctx, *args):
         await ctx.send(f"*{ctx.message.author.mention} " + " ".join(arg for arg in args) + "*")
 
 @bot.command(aliases=["list"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def list_command(ctx, cmd:str=False):
     """Lists all of the commands a user may access."""
     if cmd == False: # for quick list of commands
@@ -1482,7 +1482,7 @@ async def list_command(ctx, cmd:str=False):
         await ctx.send(embed=list)
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def school(ctx, title, state):
     lists = await getSchoolListing(title, state)
     fields = []
@@ -1604,7 +1604,7 @@ async def prepembed(ctx, channel:discord.TextChannel, *, jsonInput):
     await channel.send(embed=embed)
 
 @bot.command(aliases=["event"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def events(ctx, *args):
     """Adds or removes event roles from a user."""
     if len(args) < 1:
@@ -1680,7 +1680,7 @@ async def getWords():
     CENSORED_WORDS = getCensor()
 
 @bot.command(aliases=["man"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def help(ctx, command:str=None):
     """Allows a user to request help for a command."""
     if command == None:
@@ -1698,7 +1698,7 @@ async def help(ctx, command:str=None):
 
 @bot.command(aliases=["feedbear"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow
@@ -1721,14 +1721,14 @@ async def fish(ctx):
 
 @bot.command()
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def nofish(ctx):
     """DEPRECATED - Removes all of bear's fish."""
     await ctx.send("`!nofish` no longer exists! Please use `!stealfish` instead.")
 
 @bot.command(aliases=["badbear"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def stealfish(ctx):
     global fishNow
     member = ctx.message.author
@@ -1758,7 +1758,7 @@ async def stealfish(ctx):
 
 @bot.command(aliases=["slap", "trouts", "slaps", "troutslaps"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def trout(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. Not so fast!")
@@ -1770,7 +1770,7 @@ async def trout(ctx, member:str=False):
 
 @bot.command(aliases=["givecookie"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def cookie(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1782,14 +1782,14 @@ async def cookie(ctx, member:str=False):
 
 @bot.command()
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def treat(ctx):
     await ctx.send("You give bernard one treat!")
     await ctx.send("http://gph.is/11nJAH5")
 
 @bot.command(aliases=["givehershey", "hershey"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def hersheybar(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1801,7 +1801,7 @@ async def hersheybar(ctx, member:str=False):
 
 @bot.command(aliases=["giveicecream"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def icecream(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1818,7 +1818,7 @@ async def sanitizeMention(member):
     return True
 
 @bot.command(aliases=["div"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def division(ctx, div):
     if div.lower() == "a":
         res = await assignDiv(ctx, "Division A")
@@ -1854,7 +1854,7 @@ async def assignDiv(ctx, div):
     return True
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def alumni(ctx):
     """Removes or adds the alumni role from a user."""
     member = ctx.message.author
@@ -1981,7 +1981,7 @@ async def latex(ctx, *args):
     await ctx.send(r"https://latex.codecogs.com/png.latex?\dpi{150}{\color{Gray}" + newArgs + "}")
 
 @bot.command(aliases=["membercount"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def count(ctx):
     guild = ctx.message.author.guild
     await ctx.send(f"Currently, there are `{len(guild.members)}` members in the server.")
@@ -2023,7 +2023,7 @@ async def mute(ctx, user:discord.Member, *args):
     await _mute(ctx, user, time)
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def selfmute(ctx, *args):
     """
     Self mutes the user that invokes the command.
@@ -2108,7 +2108,7 @@ async def unban(ctx, id:int=0):
     await ctx.channel.send(f"Inverse ban hammer applied, user unbanned. Please remember that I cannot force them to re-join the server, they must join themselves.")
 
 @bot.command()
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
+@isChannelBotSpam()
 async def pronouns(ctx, *args):
     """Assigns or removes pronoun roles from a user."""
     member = ctx.message.author
@@ -2725,6 +2725,14 @@ async def on_command_error(ctx, error):
     # Command errors
     if isinstance(error, CommandNotAllowedInChannel):
         return await ctx.send(f"You are not allowed to use this command in {error.channel.mention}.")
+    if isinstance(error, CommandNotInvokedInBotSpam):
+        message = error.message
+        author = message.author
+        botspamChannel = discord.utils.get(message.guild.text_channels, name=CHANNEL_BOTSPAM)
+        clarifyMessage = await ctx.send(f"{author.mention}, please use bot commands only in {botspamChannel.mention}. If you have more questions, you can ping a global moderator.")
+        await asyncio.sleep(10)
+        await clarifyMessage.delete()
+        return await message.delete()
     if isinstance(error, discord.ext.commands.ConversionError):
         return await ctx.send("Oops, there was a bot error here, sorry about that.")
     if isinstance(error, discord.ext.commands.UserInputError):

--- a/bot.py
+++ b/bot.py
@@ -182,7 +182,7 @@ def notBlacklistedChannel(blacklist):
         for c in blacklist:
             if channel == discord.utils.get(server.text_channels, name=c):
                 # print("DENIED")
-                raise CommandNotAllowedInChannel(channel, "Command was invoked in a blacklisted channel.")
+                raise CommandNotAllowedInChannel(channel, f"Command was invoked in a blacklisted channel: {channel}.")
         return True
     
     return commands.check(predicate)
@@ -190,20 +190,30 @@ def notBlacklistedChannel(blacklist):
 def isWhitelistedChannel(whitelist):
     """Given a string array whitelist, check if command was invoked in specified whitelisted channels."""
     async def predicate(ctx):
-        channel = ctx.message.channel
-        server = bot.get_guild(SERVER_ID)
-        for c in whitelist:
-            if channel == discord.utils.get(server.text_channels, name=c):
-                return True
-        raise CommandNotAllowedInChannel(channel, "Command was invoked in a non-whitelisted channel.")
+        if not(_checkWhitelistChannel(ctx, whitelist)):
+            raise CommandNotAllowedInChannel(channel, f"Command was invoked in a non-whitelisted channel: {channel}.")
+        return True
     
     return commands.check(predicate)
+
+def _checkWhitelistChannel(ctx, whitelist):
+    channel = ctx.message.channel
+    server = bot.get_guild(SERVER_ID)
+    for c in whitelist:
+        if channel == discord.utils.get(server.text_channels, name=c):
+            return True
+        return False
     
-def isNotMember():
+def _isNotMember(ctx):
+    member = ctx.message.author
+    mrRole = discord.utils.get(member.guild.roles, name=ROLE_MR)
+    return mrRole != member.roles[-1]
+    
+def isChannelBotSpam():
     async def predicate(ctx):
-        member = ctx.message.author
-        mrRole = discord.utils.get(member.guild.roles, name=ROLE_MR)
-        return mrRole != member.roles[-1]
+        if _isNotMember(ctx) or _checkWhitelistChannel(ctx, [CHANNEL_BOTSPAM]):
+            return True
+        raise CommandNotInvokedInBotSpam(channel, ctx.message, f"A bot-spam only command was invoked in {channel}.")
     return commands.check(predicate)
 
 ##############
@@ -443,7 +453,6 @@ async def pullPrevInfo():
     print("Fetched previous variables.")
 
 @bot.command(aliases=["tc", "tourney", "tournaments"])
-@commands.check_any(isNotMember(), isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]))
 async def tournament(ctx, *args):
     member = ctx.message.author
     newArgs = list(args)

--- a/bot.py
+++ b/bot.py
@@ -177,9 +177,10 @@ def notBlacklistedChannels(blacklist):
     async def predicate(ctx):
         """Checks if command was invoked in specified blacklisted channel."""
         channel = ctx.message.channel
-        for channel in blacklist:
-            if channel.id == discord.utils.get(server.text_channels, name=channel).id:
-                print("DENIED")
+        server = bot.get_guild(SERVER_ID)
+        for c in blacklist:
+            if channel == discord.utils.get(server.text_channels, name=c):
+                # print("DENIED")
                 return False
         return True
     

--- a/bot.py
+++ b/bot.py
@@ -173,6 +173,14 @@ async def isAdmin(ctx):
     aRole = discord.utils.get(member.guild.roles, name=ROLE_AD)
     if aRole in member.roles or member.id == 715048392408956950: return True
 
+async def notBlacklistedChannels(ctx, blacklist):
+    """Checks if command was invoked in specified blacklisted channel."""
+    channel = ctx.message.channel
+    for channel in blacklist:
+        if channel.id == discord.utils.get(server.text_channels, name=channel).id:
+            return False
+    return True
+
 ##############
 # CONSTANTS
 ##############

--- a/bot.py
+++ b/bot.py
@@ -22,7 +22,7 @@ from src.sheets.events import getEvents
 from src.sheets.tournaments import getTournamentChannels
 from src.sheets.censor import getCensor
 from src.sheets.sheets import sendVariables, getVariables, getTags
-from src.forums.forums import openBrowser
+# from src.forums.forums import openBrowser
 from src.wiki.stylist import prettifyTemplates
 from src.wiki.tournaments import getTournamentList
 from src.wiki.wiki import implementCommand, getPageTables

--- a/bot.py
+++ b/bot.py
@@ -37,6 +37,7 @@ from commands import getList, getQuickList, getHelp
 from lists import getStateList
 import xkcd as xkcd_module # not to interfere with xkcd method
 from commanderrors import CommandNotAllowedInChannel
+from commanderrors import CommandNotInvokedInBotSpam
 
 load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')

--- a/bot.py
+++ b/bot.py
@@ -763,6 +763,7 @@ async def rand(ctx, a=1, b=10):
     await ctx.send(f"Random number between `{a}` and `{b}`: `{r}`")
 
 @bot.command()
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def magic8ball(ctx):
     msg = await ctx.send("Swishing the magic 8 ball...")
     await ctx.channel.trigger_typing()
@@ -793,6 +794,7 @@ async def magic8ball(ctx):
     await ctx.send(f"**{response}**")
 
 @bot.command()
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def xkcd(ctx, num = None):
     max_num = await xkcd_module.get_max()
     if num == None:
@@ -1389,6 +1391,7 @@ async def pingPM(userID, pinger, pingExp, channel, content, jumpUrl):
     await userToSend.send(embed=embed)
 
 @bot.command(aliases=["doggobomb"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def dogbomb(ctx, member:str=False):
     """Dog bombs someone!"""
     if member == False:
@@ -1398,6 +1401,7 @@ async def dogbomb(ctx, member:str=False):
     await ctx.send(f"{member}, <@{ctx.message.author.id}> dog bombed you!!")
 
 @bot.command()
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def shibabomb(ctx, member:str=False):
     """Shiba bombs a user!"""
     if member == False:
@@ -1656,7 +1660,7 @@ async def help(ctx, command:str=None):
     await ctx.send(embed=hlp)
 
 @bot.command(aliases=["feedbear"])
-@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME, CHANNEL_BOTSPAM])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow
@@ -1678,11 +1682,13 @@ async def fish(ctx):
         return await ctx.send(f":sob:\n:sob:\n:sob:\nAww, bear's fish was accidentally square root'ed. Bear now has {fishNow} fish. \n:sob:\n:sob:\n:sob:")
 
 @bot.command()
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def nofish(ctx):
     """DEPRECATED - Removes all of bear's fish."""
     await ctx.send("`!nofish` no longer exists! Please use `!stealfish` instead.")
 
 @bot.command(aliases=["badbear"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def stealfish(ctx):
     global fishNow
     member = ctx.message.author
@@ -1711,6 +1717,7 @@ async def stealfish(ctx):
         return await ctx.send("You are banned from using `!stealfish` until the next version of Pi-Bot is released.")
 
 @bot.command(aliases=["slap", "trouts", "slaps", "troutslaps"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def trout(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. Not so fast!")
@@ -1721,6 +1728,7 @@ async def trout(ctx, member:str=False):
     await ctx.send("http://gph.is/1URFXN9")
 
 @bot.command(aliases=["givecookie"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def cookie(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1731,11 +1739,13 @@ async def cookie(ctx, member:str=False):
     await ctx.send("http://gph.is/1UOaITh")
 
 @bot.command()
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def treat(ctx):
     await ctx.send("You give bernard one treat!")
     await ctx.send("http://gph.is/11nJAH5")
 
 @bot.command(aliases=["givehershey", "hershey"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def hersheybar(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1746,6 +1756,7 @@ async def hersheybar(ctx, member:str=False):
     await ctx.send("http://gph.is/2rt64CX")
 
 @bot.command(aliases=["giveicecream"])
+@notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
 async def icecream(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")

--- a/bot.py
+++ b/bot.py
@@ -186,6 +186,18 @@ def notBlacklistedChannels(blacklist):
         return True
     
     return commands.check(predicate)
+    
+def isWhitelistedChannel(whitelist):
+    """Given a string array whitelist, check if  command was invoked in specified whitelisted channel."""
+    async def predicate(ctx):
+        channel = ctx.message.channel
+        server = bot.get_guild(SERVER_ID)
+        for c in whitelist:
+            if channel == discord.utils.get(server.text_channels, name=c):
+                return True
+        return raise CommandNotAllowedInChannel(channel)
+    
+    return commands.check(predicate)
 
 ##############
 # CONSTANTS

--- a/bot.py
+++ b/bot.py
@@ -198,6 +198,13 @@ def isWhitelistedChannel(whitelist):
         return raise CommandNotAllowedInChannel(channel)
     
     return commands.check(predicate)
+    
+def isNotMember():
+    async def predicate(ctx):
+        member = ctx.message.author
+        mrRole = discord.utils.get(member.guild.roles, name=ROLE_MR)
+        return not(mrRole in member.roles)
+    return commands.check(predicate)
 
 ##############
 # CONSTANTS
@@ -436,6 +443,7 @@ async def pullPrevInfo():
     print("Fetched previous variables.")
 
 @bot.command(aliases=["tc", "tourney", "tournaments"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def tournament(ctx, *args):
     member = ctx.message.author
     newArgs = list(args)
@@ -694,21 +702,25 @@ async def refresh(ctx):
         await ctx.send(":warning: Unsuccessfully refreshed data from sheet.")
 
 @bot.command(aliases=["gci", "cid", "channelid"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def getchannelid(ctx):
     """Gets the channel ID of the current channel."""
     await ctx.send("Hey <@" + str(ctx.message.author.id) + ">! The channel ID is `" + str(ctx.message.channel.id) + "`. :)")
 
 @bot.command(aliases=["gei", "eid"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def getemojiid(ctx, emoji: discord.Emoji):
     """Gets the ID of the given emoji."""
     return await ctx.send(f"{emoji} - `{emoji}`")
 
 @bot.command(aliases=["rid"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def getroleid(ctx, name):
     role = discord.utils.get(ctx.message.author.guild.roles, name=name)
     return await ctx.send(f"`{role.mention}`")
 
 @bot.command(aliases=["ui"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def getuserid(ctx, user=None):
     """Gets the user ID of the caller or another user."""
     if user == None:
@@ -728,6 +740,7 @@ async def userfromid(ctx, iden:int):
     await ctx.send(user.mention)
 
 @bot.command(aliases=["hi"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def hello(ctx):
     """Simply says hello. Used for testing the bot."""
     await ctx.send("Well, hello there.")
@@ -815,6 +828,7 @@ async def rule(ctx, num):
     return await ctx.send(f"**Rule {num}:**\n> {rule}")
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def coach(ctx):
     """Gives an account the coach role."""
     await ctx.send("Giving you the Coach role...")
@@ -844,6 +858,7 @@ async def slowmode(ctx, arg:int=None):
             await ctx.send(f"Removed slowmode.")
 
 @bot.command(aliases=["state"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def states(ctx, *args):
     """Assigns someone with specific states."""
     newArgs = [str(arg).lower() for arg in args]
@@ -936,6 +951,7 @@ async def states(ctx, *args):
     await ctx.send(stateRes)
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def games(ctx):
     """Removes or adds someone to the games channel."""
     jbcObj = discord.utils.get(ctx.message.author.guild.text_channels, name=CHANNEL_GAMES)
@@ -1024,6 +1040,7 @@ async def unlock(ctx):
     await ctx.send("Unlocked the channel to Member access. Please check if permissions need to be synced.")
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def info(ctx):
     """Gets information about the Discord server."""
     server = ctx.message.guild
@@ -1187,6 +1204,7 @@ async def autoReport(reason, color, message):
     await message.add_reaction("\U0000274C")
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def graphpage(ctx, title, tempFormat, tableIndex, div, placeCol=0):
     temp = tempFormat.lower() in ["y", "yes", "true"]
     await ctx.send(
@@ -1222,6 +1240,7 @@ async def graphpage(ctx, title, tempFormat, tableIndex, div, placeCol=0):
     return await ctx.send("Attempted to graph.")
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def graphscilympiad(ctx, url, title):
     points = await getPoints(url)
     await _graph(points, title, "graph1.svg")
@@ -1243,6 +1262,7 @@ async def _graph(points, graph_title, title):
     await asyncio.sleep(2)
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def resultstemplate(ctx, url):
     if url.find("scilympiad.com") == -1:
         return await ctx.send("The URL must be a Scilympiad results link.")
@@ -1254,6 +1274,7 @@ async def resultstemplate(ctx, url):
     await ctx.send(file=file)
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def ping(ctx, command=None, *args):
     """Controls Pi-Bot's ping interface."""
     if command is None:
@@ -1352,6 +1373,7 @@ async def ping(ctx, command=None, *args):
         return await ctx.send("Sorry, I can't find that command.")
 
 @bot.command(aliases=["donotdisturb"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def dnd(ctx):
     member = ctx.message.author.id
     if any([True for u in PING_INFO if u['id'] == member]):
@@ -1420,6 +1442,7 @@ async def me(ctx, *args):
         await ctx.send(f"*{ctx.message.author.mention} " + " ".join(arg for arg in args) + "*")
 
 @bot.command(aliases=["list"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def list_command(ctx, cmd:str=False):
     """Lists all of the commands a user may access."""
     if cmd == False: # for quick list of commands
@@ -1448,6 +1471,7 @@ async def list_command(ctx, cmd:str=False):
         await ctx.send(embed=list)
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def school(ctx, title, state):
     lists = await getSchoolListing(title, state)
     fields = []
@@ -1569,6 +1593,7 @@ async def prepembed(ctx, channel:discord.TextChannel, *, jsonInput):
     await channel.send(embed=embed)
 
 @bot.command(aliases=["event"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def events(ctx, *args):
     """Adds or removes event roles from a user."""
     if len(args) < 1:
@@ -1644,6 +1669,7 @@ async def getWords():
     CENSORED_WORDS = getCensor()
 
 @bot.command(aliases=["man"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def help(ctx, command:str=None):
     """Allows a user to request help for a command."""
     if command == None:
@@ -1661,6 +1687,7 @@ async def help(ctx, command:str=None):
 
 @bot.command(aliases=["feedbear"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow
@@ -1683,12 +1710,14 @@ async def fish(ctx):
 
 @bot.command()
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def nofish(ctx):
     """DEPRECATED - Removes all of bear's fish."""
     await ctx.send("`!nofish` no longer exists! Please use `!stealfish` instead.")
 
 @bot.command(aliases=["badbear"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def stealfish(ctx):
     global fishNow
     member = ctx.message.author
@@ -1718,6 +1747,7 @@ async def stealfish(ctx):
 
 @bot.command(aliases=["slap", "trouts", "slaps", "troutslaps"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def trout(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. Not so fast!")
@@ -1729,6 +1759,7 @@ async def trout(ctx, member:str=False):
 
 @bot.command(aliases=["givecookie"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def cookie(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1740,12 +1771,14 @@ async def cookie(ctx, member:str=False):
 
 @bot.command()
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def treat(ctx):
     await ctx.send("You give bernard one treat!")
     await ctx.send("http://gph.is/11nJAH5")
 
 @bot.command(aliases=["givehershey", "hershey"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def hersheybar(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1757,6 +1790,7 @@ async def hersheybar(ctx, member:str=False):
 
 @bot.command(aliases=["giveicecream"])
 @notBlacklistedChannel(blacklist=[CHANNEL_WELCOME])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def icecream(ctx, member:str=False):
     if await sanitizeMention(member) == False:
         return await ctx.send("Woah... looks like you're trying to be a little sneaky with what you're telling me to do. You can't ping roles or everyone.")
@@ -1773,6 +1807,7 @@ async def sanitizeMention(member):
     return True
 
 @bot.command(aliases=["div"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def division(ctx, div):
     if div.lower() == "a":
         res = await assignDiv(ctx, "Division A")
@@ -1808,6 +1843,7 @@ async def assignDiv(ctx, div):
     return True
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def alumni(ctx):
     """Removes or adds the alumni role from a user."""
     member = ctx.message.author
@@ -1934,6 +1970,7 @@ async def latex(ctx, *args):
     await ctx.send(r"https://latex.codecogs.com/png.latex?\dpi{150}{\color{Gray}" + newArgs + "}")
 
 @bot.command(aliases=["membercount"])
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def count(ctx):
     guild = ctx.message.author.guild
     await ctx.send(f"Currently, there are `{len(guild.members)}` members in the server.")
@@ -1975,6 +2012,7 @@ async def mute(ctx, user:discord.Member, *args):
     await _mute(ctx, user, time)
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def selfmute(ctx, *args):
     """
     Self mutes the user that invokes the command.
@@ -2059,6 +2097,7 @@ async def unban(ctx, id:int=0):
     await ctx.channel.send(f"Inverse ban hammer applied, user unbanned. Please remember that I cannot force them to re-join the server, they must join themselves.")
 
 @bot.command()
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_BOTSPAM]), isNotMember())
 async def pronouns(ctx, *args):
     """Assigns or removes pronoun roles from a user."""
     member = ctx.message.author
@@ -2104,6 +2143,7 @@ async def pronouns(ctx, *args):
 
 @bot.command()
 @commands.check(isLauncher)
+@commands.check_any(isWhitelistedChannel(whitelist=[CHANNEL_WELCOME]))
 async def confirm(ctx, *args: discord.Member):
     """Allows a staff member to confirm a user."""
     await _confirm(args)
@@ -2277,18 +2317,18 @@ async def on_message(message):
 
     # Prevent command usage in channels outside of #bot-spam
     author = message.author
-    if type(message.channel) != discord.DMChannel and message.content.startswith(BOT_PREFIX) and author.roles[-1] == discord.utils.get(author.guild.roles, name=ROLE_MR):
-        if message.channel.name != CHANNEL_BOTSPAM:
-            allowedCommands = ["about", "dogbomb", "exchange", "gallery", "invite", "me", "magic8ball", "latex", "obb", "profile", "r", "report", "rule", "shibabomb", "tag", "wiki", "wikipedia", "wp"]
-            allowed = False
-            for c in allowedCommands:
-                if message.content.find(BOT_PREFIX + c) != -1: allowed = True
-            if not allowed:
-                botspamChannel = discord.utils.get(message.guild.text_channels, name=CHANNEL_BOTSPAM)
-                clarifyMessage = await message.channel.send(f"{author.mention}, please use bot commands only in {botspamChannel.mention}. If you have more questions, you can ping a global moderator.")
-                await asyncio.sleep(10)
-                await clarifyMessage.delete()
-                return await message.delete()
+    # if type(message.channel) != discord.DMChannel and message.content.startswith(BOT_PREFIX) and author.roles[-1] == discord.utils.get(author.guild.roles, name=ROLE_MR):
+    #     if message.channel.name != CHANNEL_BOTSPAM:
+    #         allowedCommands = ["about", "dogbomb", "exchange", "gallery", "invite", "me", "magic8ball", "latex", "obb", "profile", "r", "report", "rule", "shibabomb", "tag", "wiki", "wikipedia", "wp"]
+    #         allowed = False
+    #         for c in allowedCommands:
+    #             if message.content.find(BOT_PREFIX + c) != -1: allowed = True
+    #         if not allowed:
+    #             botspamChannel = discord.utils.get(message.guild.text_channels, name=CHANNEL_BOTSPAM)
+    #             clarifyMessage = await message.channel.send(f"{author.mention}, please use bot commands only in {botspamChannel.mention}. If you have more questions, you can ping a global moderator.")
+    #             await asyncio.sleep(10)
+    #             await clarifyMessage.delete()
+    #             return await message.delete()
 
     if message.author.id in PI_BOT_IDS: return
     content = message.content

--- a/commanderrors.py
+++ b/commanderrors.py
@@ -1,5 +1,5 @@
 import discord.ext.commands as commands
-class BlacklistException(commands.CommandError):
+class CommandNotAllowedInChannel(commands.CommandError):
     def __init__(self, channel, *args, **kwargs):
         self.channel = channel
         super().__init__(*args, **kwargs)

--- a/commanderrors.py
+++ b/commanderrors.py
@@ -1,5 +1,13 @@
 import discord.ext.commands as commands
+
 class CommandNotAllowedInChannel(commands.CommandError):
     def __init__(self, channel, *args, **kwargs):
         self.channel = channel
+        super().__init__(*args, **kwargs)
+        
+        
+class CommandNotInvokedInBotSpam(commands.CommandError):
+    def __init__(self, channel, message, *args, **kwargs):
+        self.channel = channel
+        self.message = message
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Wanted to use command cogs to make bot-spam only commands easier to distinguish. Also makes implementing future commands easier rather than having to go to specific parts of the code to change. This branch does include the fix to issue #305 .