### PR TITLE
Issue #296: PM check for !ping

### DIFF
--- a/blacklistexception.py
+++ b/blacklistexception.py
@@ -1,0 +1,5 @@
+import discord.ext.commands as commands
+class BlacklistException(commands.CommandError):
+    def __init__(self, channel, *args, **kwargs):
+        self.channel = channel
+        super().__init__(*args, **kwargs)

--- a/bot.py
+++ b/bot.py
@@ -173,13 +173,17 @@ async def isAdmin(ctx):
     aRole = discord.utils.get(member.guild.roles, name=ROLE_AD)
     if aRole in member.roles or member.id == 715048392408956950: return True
 
-async def notBlacklistedChannels(ctx, blacklist):
-    """Checks if command was invoked in specified blacklisted channel."""
-    channel = ctx.message.channel
-    for channel in blacklist:
-        if channel.id == discord.utils.get(server.text_channels, name=channel).id:
-            return False
-    return True
+def notBlacklistedChannels(blacklist):
+    async def predicate(ctx):
+        """Checks if command was invoked in specified blacklisted channel."""
+        channel = ctx.message.channel
+        for channel in blacklist:
+            if channel.id == discord.utils.get(server.text_channels, name=channel).id:
+                print("DENIED")
+                return False
+        return True
+    
+    return commands.check(predicate)
 
 ##############
 # CONSTANTS
@@ -1638,6 +1642,7 @@ async def help(ctx, command:str=None):
     await ctx.send(embed=hlp)
 
 @bot.command(aliases=["feedbear"])
+@commands.check(notBlacklistedChannels(blacklist=["welcome"]))
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow

--- a/bot.py
+++ b/bot.py
@@ -36,7 +36,7 @@ from embed import assembleEmbed
 from commands import getList, getQuickList, getHelp
 from lists import getStateList
 import xkcd as xkcd_module # not to interfere with xkcd method
-from blacklistexception import BlacklistException
+from commanderrors import CommandNotAllowedInChannel
 
 load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')
@@ -182,7 +182,7 @@ def notBlacklistedChannels(blacklist):
         for c in blacklist:
             if channel == discord.utils.get(server.text_channels, name=c):
                 # print("DENIED")
-                raise BlacklistException(channel)
+                raise CommandNotAllowedInChannel(channel)
         return True
     
     return commands.check(predicate)
@@ -2649,7 +2649,7 @@ async def on_command_error(ctx, error):
         return await ctx.send("Uh... this channel can only be run in a NSFW channel... sorry to disappoint.")
 
     # Command errors
-    if isinstance(error, BlacklistException):
+    if isinstance(error, CommandNotAllowedInChannel):
         return await ctx.send(f"You are not allowed to use this command in {error.channel.mention}.")
     if isinstance(error, discord.ext.commands.ConversionError):
         return await ctx.send("Oops, there was a bot error here, sorry about that.")
@@ -2662,9 +2662,6 @@ async def on_command_error(ctx, error):
     if isinstance(error, discord.ext.commands.DisabledCommand):
         return await ctx.send("Sorry, but this command is disabled.")
     if isinstance(error, discord.ext.commands.CommandInvokeError):
-        # if isinstance(error.original, BlacklistException):
-        #     return await ctx.send("You are not allowed to run that command here smh")
-        # else:
         return await ctx.send("Sorry, but an error incurred when the command was invoked.")
     if isinstance(error, discord.ext.commands.CommandOnCooldown):
         return await ctx.send("Slow down buster! This command's on cooldown.")

--- a/bot.py
+++ b/bot.py
@@ -1643,7 +1643,7 @@ async def help(ctx, command:str=None):
     await ctx.send(embed=hlp)
 
 @bot.command(aliases=["feedbear"])
-@commands.check(notBlacklistedChannels(blacklist=["welcome"]))
+@notBlacklistedChannels(blacklist=[CHANNEL_WELCOME])
 async def fish(ctx):
     """Gives a fish to bear."""
     global fishNow

--- a/bot.py
+++ b/bot.py
@@ -2647,6 +2647,8 @@ async def on_command_error(ctx, error):
         return await ctx.send("Sorry, I'm having trouble reading one of the arguments you just used. Try again!")
 
     # Check failure errors
+    if isinstance(error, NoDMsAllowed):
+        return await ctx.send("Pings require direct messages to be sent to you. You need to turn on \"Allow direct messages from server members.\"")
     if isinstance(error, discord.ext.commands.CheckAnyFailure):
         return await ctx.send("It looks like you aren't able to run this command, sorry.")
     if isinstance(error, discord.ext.commands.PrivateMessageOnly):

--- a/bot.py
+++ b/bot.py
@@ -187,6 +187,20 @@ def notBlacklistedChannels(blacklist):
         return True
     
     return commands.check(predicate)
+    
+def checkDM():
+    """Checks if the user has DM permissions. If the send responds 403, then they have DMs disabled."""
+    async def predicate(ctx):
+        user = ctx.message.author
+        try:
+            await user.send("")
+        except discord.Forbidden:
+            raise NoDMsAllowed(user, f"{user} has DMs set to off.")
+        except discord.HTTPException:
+            pass
+        return True
+    
+    return commands.check(predicate)
 
 ##############
 # CONSTANTS

--- a/bot.py
+++ b/bot.py
@@ -177,9 +177,10 @@ def notBlacklistedChannels(blacklist):
     async def predicate(ctx):
         """Checks if command was invoked in specified blacklisted channel."""
         channel = ctx.message.channel
-        for channel in blacklist:
-            if channel.id == discord.utils.get(server.text_channels, name=channel).id:
-                print("DENIED")
+        server = bot.get_guild(SERVER_ID)
+        for c in blacklist:
+            if channel == discord.utils.get(server.text_channels, name=c):
+                # print("DENIED")
                 return False
         return True
     

--- a/bot.py
+++ b/bot.py
@@ -173,6 +173,14 @@ async def isAdmin(ctx):
     aRole = discord.utils.get(member.guild.roles, name=ROLE_AD)
     if aRole in member.roles or member.id == 715048392408956950: return True
 
+async def notBlacklistedChannels(ctx, blacklist):
+    """Checks if command was invoked in specified blacklisted channel."""
+    channel = ctx.message.channel
+    for channel in blacklist:
+        if channel.id == discord.utils.get(server.text_channels, name=channel).id:
+            return False
+    return True
+
 ##############
 # CONSTANTS
 ##############

--- a/bot.py
+++ b/bot.py
@@ -1255,6 +1255,7 @@ async def resultstemplate(ctx, url):
     await ctx.send(file=file)
 
 @bot.command()
+@checkDM()
 async def ping(ctx, command=None, *args):
     """Controls Pi-Bot's ping interface."""
     if command is None:

--- a/bot.py
+++ b/bot.py
@@ -37,6 +37,7 @@ from commands import getList, getQuickList, getHelp
 from lists import getStateList
 import xkcd as xkcd_module # not to interfere with xkcd method
 from commanderrors import CommandNotAllowedInChannel
+from commanderrors import NoDMsAllowed
 
 load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')

--- a/commanderrors.py
+++ b/commanderrors.py
@@ -3,3 +3,8 @@ class CommandNotAllowedInChannel(commands.CommandError):
     def __init__(self, channel, *args, **kwargs):
         self.channel = channel
         super().__init__(*args, **kwargs)
+        
+class NoDMsAllowed(commands.CommandError):
+    def __init__(self, user, *args, **kwargs):
+        self.channel = channel
+        super().__init__(*args, **kwargs)

--- a/commanderrors.py
+++ b/commanderrors.py
@@ -1,5 +1,5 @@
 import discord.ext.commands as commands
-class BlacklistException(commands.CommandError):
+class CommandNotAllowedInChannel(commands.CommandError):
     def __init__(self, channel, *args, **kwargs):
         self.channel = channel
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Attempts to send an empty message to user DM. If the user has "Allow direct messages from server members" turned off, then a 403 error will occur. Otherwise, then a 400 error occurs since Discord prevents from sending empty messages. Closes #296 .