### PR TITLE
Issue #320: Member Count VC

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -266,7 +266,6 @@ async def updateMemberCount():
     guild = bot.get_guild(SERVER_ID)
     vc = discord.utils.get(guild.voice_channels, bitrate=8000)
     mem_count = guild.member_count
-    print(vc)
     await vc.edit(name=f"Member Count: {mem_count}")
     print("Refreshed member count.")
 

--- a/bot.py
+++ b/bot.py
@@ -258,6 +258,17 @@ async def on_ready():
     manage_welcome.start()
     storeVariables.start()
     changeBotStatus.start()
+    updateCount.start()
+    
+@tasks.loop(minutes=1)
+async def updateCount():
+    """Refreshes the censor list and stores variable backups."""
+    guild = bot.get_guild(SERVER_ID)
+    vc = discord.utils.get(guild.voice_channels, bitrate=8000)
+    mem_count = guild.member_count
+    print(vc)
+    await vc.edit(name=f"Member Count: {mem_count}")
+    print("Refreshed member count.")
 
 @tasks.loop(seconds=30.0)
 async def refreshSheet():

--- a/bot.py
+++ b/bot.py
@@ -260,7 +260,7 @@ async def on_ready():
     changeBotStatus.start()
     updateMemberCount.start()
     
-@tasks.loop(minutes=1)
+@tasks.loop(minutes=5)
 async def updateMemberCount():
     """Updates the member count shown on hidden VC"""
     guild = bot.get_guild(SERVER_ID)

--- a/bot.py
+++ b/bot.py
@@ -264,7 +264,8 @@ async def on_ready():
 async def updateMemberCount():
     """Updates the member count shown on hidden VC"""
     guild = bot.get_guild(SERVER_ID)
-    vc = discord.utils.get(guild.voice_channels, bitrate=8000)
+    channel_prefix = "Member Count"
+    vc = discord.utils.find(lambda c: channel_prefix in c.name, guild.voice_channels)
     mem_count = guild.member_count
     await vc.edit(name=f"Member Count: {mem_count}")
     print("Refreshed member count.")

--- a/bot.py
+++ b/bot.py
@@ -262,7 +262,7 @@ async def on_ready():
     
 @tasks.loop(minutes=1)
 async def updateCount():
-    """Refreshes the censor list and stores variable backups."""
+    """Updates the member count shown on hidden VC"""
     guild = bot.get_guild(SERVER_ID)
     vc = discord.utils.get(guild.voice_channels, bitrate=8000)
     mem_count = guild.member_count

--- a/bot.py
+++ b/bot.py
@@ -264,10 +264,14 @@ async def on_ready():
 async def updateMemberCount():
     """Updates the member count shown on hidden VC"""
     guild = bot.get_guild(SERVER_ID)
-    channel_prefix = "Member Count"
+    channel_prefix = "Members"
     vc = discord.utils.find(lambda c: channel_prefix in c.name, guild.voice_channels)
     mem_count = guild.member_count
-    await vc.edit(name=f"Member Count: {mem_count}")
+    joined_today = len([m for m in guild.members if m.joined_at.date() == datetime.datetime.today().date()])
+    left_channel = discord.utils.get(guild.text_channels, name=CHANNEL_LEAVE)
+    left_messages = await left_channel.history(limit=200).flatten()
+    left_today = len([m for m in left_messages if m.created_at.date() == datetime.datetime.today().date()])
+    await vc.edit(name=f"{mem_count} Members (+{joined_today}/-{left_today})")
     print("Refreshed member count.")
 
 @tasks.loop(seconds=30.0)

--- a/bot.py
+++ b/bot.py
@@ -258,10 +258,10 @@ async def on_ready():
     manage_welcome.start()
     storeVariables.start()
     changeBotStatus.start()
-    updateCount.start()
+    updateMemberCount.start()
     
 @tasks.loop(minutes=1)
-async def updateCount():
+async def updateMemberCount():
     """Updates the member count shown on hidden VC"""
     guild = bot.get_guild(SERVER_ID)
     vc = discord.utils.get(guild.voice_channels, bitrate=8000)


### PR DESCRIPTION
Closes #320 . Added a new task that updates the VC every minute. I originally had it use the bitrate to search for the VC, but since the server would only have 2 VCs, I decided it probably be best to just compare the name even though it has a slower runtime.

To implement the VC, create a voice channel named "Member Count."
In channel permissions:
Disable `View Channel` and `Connect` for everyone.
Pi-Bot will need to have, `Connect`, `View Channel`, and `Manage Channel` all enabled.
Mods need `View Channel` and `Manage Channel` at the minimum.