### PR TITLE
Issue #298: Fixed DM logging errors

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2560,13 +2560,15 @@ async def on_raw_message_edit(payload):
 
 @bot.event
 async def on_raw_message_delete(payload):
-    if bot.get_channel(payload.channel_id).name in [CHANNEL_REPORTS, CHANNEL_DELETEDM]:
+    channel = bot.get_channel(payload.channel_id)
+    guild = bot.get_guild(SERVER_ID) if channel.type == discord.ChannelType.private else channel.guild
+    if channel.type != discord.ChannelType.private and channel.name in [CHANNEL_REPORTS, CHANNEL_DELETEDM]:
         print("Ignoring deletion event because of the channel it's from.")
         return
-    channel = bot.get_channel(payload.channel_id)
-    deletedChannel = discord.utils.get(channel.guild.text_channels, name=CHANNEL_DELETEDM)
+    deletedChannel = discord.utils.get(guild.text_channels, name=CHANNEL_DELETEDM)
     try:
         message = payload.cached_message
+        channelName = f"{message.author.mention}'s DM" if channel.type == discord.ChannelType.private else message.channel.mention
         embed = assembleEmbed(
             title=":fire: Deleted Message",
             fields=[
@@ -2577,7 +2579,7 @@ async def on_raw_message_delete(payload):
                 },
                 {
                     "name": "Channel",
-                    "value": message.channel.mention,
+                    "value": channelName,
                     "inline": "True"
                 },
                 {

--- a/bot.py
+++ b/bot.py
@@ -2503,7 +2503,7 @@ async def on_raw_message_edit(payload):
                 }
             ]
         )
-        await editedChannel.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+        await editedChannel.send(embed=embed)
     except Exception as e:
         msgNow = await channel.fetch_message(payload.message_id)
         embed = assembleEmbed(
@@ -2556,7 +2556,7 @@ async def on_raw_message_edit(payload):
                 }
             ]
         )
-        await editedChannel.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+        await editedChannel.send(embed=embed)
 
 @bot.event
 async def on_raw_message_delete(payload):
@@ -2612,7 +2612,7 @@ async def on_raw_message_delete(payload):
                 }
             ]
         )
-        await deletedChannel.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+        await deletedChannel.send(embed=embed)
     except Exception as e:
         print(e)
         embed = assembleEmbed(
@@ -2630,7 +2630,7 @@ async def on_raw_message_delete(payload):
                 }
             ]
         )
-        await deletedChannel.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
+        await deletedChannel.send(embed=embed)
 
 @bot.event
 async def on_command_error(ctx, error):

--- a/bot.py
+++ b/bot.py
@@ -2503,7 +2503,7 @@ async def on_raw_message_edit(payload):
                 }
             ]
         )
-        await editedChannel.send(embed=embed)
+        await editedChannel.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
     except Exception as e:
         msgNow = await channel.fetch_message(payload.message_id)
         embed = assembleEmbed(
@@ -2556,7 +2556,7 @@ async def on_raw_message_edit(payload):
                 }
             ]
         )
-        await editedChannel.send(embed=embed)
+        await editedChannel.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
 
 @bot.event
 async def on_raw_message_delete(payload):
@@ -2612,7 +2612,7 @@ async def on_raw_message_delete(payload):
                 }
             ]
         )
-        await deletedChannel.send(embed=embed)
+        await deletedChannel.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
     except Exception as e:
         print(e)
         embed = assembleEmbed(
@@ -2630,7 +2630,7 @@ async def on_raw_message_delete(payload):
                 }
             ]
         )
-        await deletedChannel.send(embed=embed)
+        await deletedChannel.send(embed=embed, allowed_mentions=discord.AllowedMentions.none())
 
 @bot.event
 async def on_command_error(ctx, error):

--- a/bot.py
+++ b/bot.py
@@ -2445,12 +2445,14 @@ async def on_user_update(before, after):
 @bot.event
 async def on_raw_message_edit(payload):
     channel = bot.get_channel(payload.channel_id)
-    editedChannel = discord.utils.get(channel.guild.text_channels, name=CHANNEL_EDITEDM)
-    if channel.name in [CHANNEL_EDITEDM, CHANNEL_DELETEDM]:
+    guild = bot.get_guild(SERVER_ID) if channel.type == discord.ChannelType.private else channel.guild
+    editedChannel = discord.utils.get(guild.text_channels, name=CHANNEL_EDITEDM)
+    if channel.type != discord.ChannelType.private and channel.name in [CHANNEL_EDITEDM, CHANNEL_DELETEDM, CHANNEL_DMLOG]:
         return
     try:
         message = payload.cached_message
         msgNow = await channel.fetch_message(message.id)
+        channelName = f"{message.author.mention}'s DM" if channel.type == discord.ChannelType.private else message.channel.mention
         embed = assembleEmbed(
             title=":pencil: Edited Message",
             fields=[
@@ -2461,7 +2463,7 @@ async def on_raw_message_edit(payload):
                 },
                 {
                     "name": "Channel",
-                    "value": message.channel.mention,
+                    "value": channelName,
                     "inline": "True"
                 },
                 {


### PR DESCRIPTION
Closes #298. Didn't know _exactly_ what to look for here, but I just cleared up the errors produced when a DM was sent to Pi-Bot as well as when any messages were edited in DMs.