### PR TITLE
Issue #340: Fixed MET graph not being deallocated after file save

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1524,6 +1524,7 @@ async def met(ctx):
     plt.title("Top wiki editors for the past week!")
     plt.tight_layout()
     plt.savefig("met.png")
+    plt.close()
     await msg1.delete()
     msg2 = await ctx.send("Generating graph...")
     await asyncio.sleep(3)


### PR DESCRIPTION
Closes #340. The plot needs to be closed after it's saved in order for pyplot to deallocate the graph from memory.