### PR TITLE
Issue #403: Catch users still using prefix commands

### DIFF
--- a/src/discord/logger.py
+++ b/src/discord/logger.py
@@ -282,7 +282,7 @@ class Logger(commands.Cog):
                 self.bot.tree.get_commands(guild=discord.Object(s_id))
                 for s_id in SLASH_COMMAND_GUILDS
             ]
-            invoked_command = ctx.message.content[1:].split(' ')[0]
+            invoked_command = ctx.message.content[1:].split(" ")[0]
             if invoked_command in [
                 c.name for c in itertools.chain.from_iterable(slash_commands)
             ]:

--- a/src/discord/logger.py
+++ b/src/discord/logger.py
@@ -282,11 +282,12 @@ class Logger(commands.Cog):
                 self.bot.tree.get_commands(guild=discord.Object(s_id))
                 for s_id in SLASH_COMMAND_GUILDS
             ]
-            if ctx.command.name in [
+            invoked_command = ctx.message.content[1:].split(' ')[0]
+            if invoked_command in [
                 c.name for c in itertools.chain.from_iterable(slash_commands)
             ]:
                 return await ctx.send(
-                    f"{ctx.author.mention}, please use slash commands (`/{ctx.command.name}`) instead!\n"
+                    f"{ctx.author.mention}, please use slash commands (`/{invoked_command}`) instead!\n"
                     f"Pi-bot has officially made the switch to slash commands to make the user experience cleaner and easier. "
                 )
             return await ctx.send(

--- a/src/discord/logger.py
+++ b/src/discord/logger.py
@@ -4,6 +4,7 @@ buckets, such as a Discord channel or database log.
 """
 from __future__ import annotations
 
+import itertools
 import traceback
 from typing import TYPE_CHECKING
 
@@ -19,6 +20,7 @@ from src.discord.globals import (
     CHANNEL_WELCOME,
     ROLE_UC,
     SERVER_ID,
+    SLASH_COMMAND_GUILDS,
 )
 
 if TYPE_CHECKING:
@@ -276,7 +278,22 @@ class Logger(commands.Cog):
                 "Hmmm... I'm having trouble reading what you're trying to tell me."
             )
         if isinstance(error, discord.ext.commands.CommandNotFound):
-            return await ctx.send("Sorry, I couldn't find that command.")
+            slash_commands = [
+                self.bot.tree.get_commands(guild=discord.Object(s_id))
+                for s_id in SLASH_COMMAND_GUILDS
+            ]
+            if ctx.command.name in [
+                c.name for c in itertools.chain.from_iterable(slash_commands)
+            ]:
+                return await ctx.send(
+                    f"{ctx.author.mention}, please use slash commands (`/{ctx.command.name}`) instead!\n"
+                    f"Pi-bot has officially made the switch to slash commands to make the user experience cleaner and easier. "
+                )
+            return await ctx.send(
+                f"{ctx.author.mention}, please use slash commands e.g, (`/states state: Florida`) instead!\n"
+                f"Pi-bot has officially made the switch to slash commands to make the user experience cleaner and easier. "
+            )
+
         if isinstance(error, discord.ext.commands.CheckFailure):
             return await ctx.send("Sorry, but I don't think you can run that command.")
         if isinstance(error, discord.ext.commands.DisabledCommand):


### PR DESCRIPTION
# Description
<!-- Please explain what you changed in this pull request: -->
Added to the `on_command_error` handler, the bot will search for an application command with the same name. If found the bot will direct the user to use that specific slash command. If not found, it will send a general message to use slash commands. 


# Checks
<!-- Have you done the following? -->

- [x] I ran `black` over the code to ensure formatting.
- [x] I added docstrings to **any** new modules, classes, and methods.
- [x] I updated the docstrings of **any** updated modules, classes, and methods.
- [x] I added/updated Python typings for any new/updated class and module.
- [x] I updated the bot version (if necessary).
- [x] I ran mypy and reviewed any shown errors related to my changes.

# Important Info
<!-- Does any of this apply to your pull request? -->

- [ ] This pull request adds new `pip` dependencies.
- [] This pull request adds new external dependencies.
- [ ] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:

- #403 

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
