### PR TITLE
Issue #318: Add reply context to auto censor messages

### DIFF
--- a/src/discord/censor.py
+++ b/src/discord/censor.py
@@ -112,6 +112,7 @@ class Censor(commands.Cog):
         webhook = await channel.create_webhook(name="Censor (Automated)")
         content = message.content
         author = message.author.nick or message.author.name
+        reply = message.reference
 
         # Actually replace content found on the censored words/emojis list
         for word in src.discord.globals.CENSOR["words"]:
@@ -123,12 +124,22 @@ class Censor(commands.Cog):
 
         # Make sure pinging through @everyone, @here, or any role can not happen
         mention_perms = discord.AllowedMentions(everyone=False, users=True, roles=False)
-        await webhook.send(
-            content,
-            username=f"{author} (auto-censor)",
-            avatar_url=avatar,
-            allowed_mentions=mention_perms,
-        )
+        if reply:
+            reply_message = (f'*Replying to {reply.cached_message.author.mention}*'
+                             f'\n>[{reply.cached_message.content[:80]}...]({reply.cached_message.jump_url})\n')
+            await webhook.send(
+                reply_message + content,
+                username=f"{author} (auto-censor)",
+                avatar_url=avatar,
+                allowed_mentions=mention_perms,
+            )
+        else:
+            await webhook.send(
+                content,
+                username=f"{author} (auto-censor)",
+                avatar_url=avatar,
+                allowed_mentions=mention_perms,
+            )
         await webhook.delete()
 
         # Replace content with censored content for other cogs


### PR DESCRIPTION
# Description
<!-- Please explain what you changed in this pull request: -->
If a message was caught by auto censor and was replying to another user, PiBot will now add that context to the autocensor message. 


# Checks
<!-- Have you done the following? -->

- [ ] I ran `black` over the code to ensure formatting.
- [ ] I added docstrings to **any** new modules, classes, and methods.
- [ ] I updated the docstrings of **any** updated modules, classes, and methods.
- [ ] I added/updated Python typings for any new/updated class and module.
- [ ] I updated the bot version (if necessary).
- [ ] I ran mypy and reviewed any shown errors related to my changes.

# Important Info
<!-- Does any of this apply to your pull request? -->

- [ ] This pull request adds new `pip` dependencies.
- [ ] This pull request adds new external dependencies.
- [ ] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:

- #318  

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
