### PR TITLE
Fix removal of all pings to persist across to database

### DIFF
--- a/src/discord/ping.py
+++ b/src/discord/ping.py
@@ -1,6 +1,7 @@
 """
 Holds functionality for members to manage their ping subscriptions.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -459,7 +460,7 @@ class PingManager(commands.GroupCog, name="ping"):
                 "data",
                 "pings",
                 user["_id"],
-                {"$pull": {"word_pings": {}}},
+                {"$set": {"word_pings": []}},
             )
             return await interaction.response.send_message(
                 "I removed all of your pings.",


### PR DESCRIPTION
# Description
Fixes issue where `/ping remove all` does not remove all pings in the database, so a bot restart brings back old pings.



# Checks

- [x] I ran `black` over the code to ensure formatting.
- [ ] I added docstrings to **any** new modules, classes, and methods.
- [ ] I updated the docstrings of **any** updated modules, classes, and methods.
- [ ] I added/updated Python typings for any new/updated class and module.
- [ ] I updated the bot version (if necessary).
- [ ] I ran mypy and reviewed any shown errors related to my changes.

# Important Info

- [ ] This pull request adds new `pip` dependencies.
- [ ] This pull request adds new external dependencies.
- [ ] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:
None, but it is a bug, as reported by @kleinerPanzer [on Discord](https://discord.com/channels/698306997287780363/973011006034944100/1232425037617958942).

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
