### PR TITLE
Remove Discord autocomplete magic number

### DIFF
--- a/src/discord/globals.py
+++ b/src/discord/globals.py
@@ -114,6 +114,8 @@ RULES = [
     ),
 ]
 
+DISCORD_AUTOCOMPLETE_MAX_ENTRIES = 25
+
 ##############
 # VARIABLES
 ##############

--- a/src/discord/invitationals.py
+++ b/src/discord/invitationals.py
@@ -14,6 +14,7 @@ from src.discord.globals import (
     CHANNEL_COMPETITIONS,
     CHANNEL_INVITATIONALS,
     CHANNEL_SUPPORT,
+    DISCORD_AUTOCOMPLETE_MAX_ENTRIES,
     ROLE_AD,
     ROLE_AT,
     ROLE_GM,
@@ -442,7 +443,7 @@ async def update_invitational_list(bot: PiBot, rename_dict: dict = {}) -> None:
             if t.tourney_date.month == month["number"]
             and t.tourney_date.year == month["year"]
             and t.status in ["open", "archived"]
-        ][:25]
+        ][:DISCORD_AUTOCOMPLETE_MAX_ENTRIES]
         if len(month_invitationals) > 0:
             await invitational_channel.send(
                 f"Invitationals in **{month['name']} {month['year']}**:",

--- a/src/discord/membercommands.py
+++ b/src/discord/membercommands.py
@@ -23,6 +23,7 @@ from src.discord.globals import (
     CHANNEL_GAMES,
     CHANNEL_INVITATIONALS,
     CHANNEL_UNSELFMUTE,
+    DISCORD_AUTOCOMPLETE_MAX_ENTRIES,
     ROLE_ALUMNI,
     ROLE_DIV_A,
     ROLE_DIV_B,
@@ -516,7 +517,7 @@ class MemberCommands(commands.Cog):
             app_commands.Choice(name=state, value=state)
             for state in states
             if current.lower() in state.lower()
-        ][:25]
+        ][:DISCORD_AUTOCOMPLETE_MAX_ENTRIES]
 
     @app_commands.command(description="Mutes yourself.")
     @app_commands.describe(mute_length="How long to mute yourself for.")
@@ -1249,7 +1250,7 @@ class MemberCommands(commands.Cog):
             app_commands.Choice(name=e["name"], value=e["name"])
             for e in src.discord.globals.EVENT_INFO
             if current.lower() in e["name"].lower()
-        ][:25]
+        ][:DISCORD_AUTOCOMPLETE_MAX_ENTRIES]
 
     @app_commands.command(description="Gets a tag.")
     @app_commands.describe(tag_name="The name of the tag to get.")

--- a/src/discord/staff/invitationals.py
+++ b/src/discord/staff/invitationals.py
@@ -13,6 +13,7 @@ from env import env
 from src.discord.globals import (
     CATEGORY_ARCHIVE,
     CATEGORY_INVITATIONALS,
+    DISCORD_AUTOCOMPLETE_MAX_ENTRIES,
     EMOJI_LOADING,
     ROLE_STAFF,
     ROLE_VIP,
@@ -737,7 +738,7 @@ class StaffInvitational(commands.Cog):
             )
             for i in invitationals
             if current.lower() in i["channel_name"].lower() and i["status"] == "voting"
-        ][:25]
+        ][:DISCORD_AUTOCOMPLETE_MAX_ENTRIES]
 
     @invitational_edit.autocomplete("short_name")
     @invitational_delete.autocomplete("short_name")
@@ -754,7 +755,7 @@ class StaffInvitational(commands.Cog):
             )
             for i in invitationals
             if current.lower() in i["channel_name"].lower()
-        ][:25]
+        ][:DISCORD_AUTOCOMPLETE_MAX_ENTRIES]
 
     @invitational_archive.autocomplete("short_name")
     async def short_name_archive_autocomplete(
@@ -770,7 +771,7 @@ class StaffInvitational(commands.Cog):
             )
             for i in invitationals
             if current.lower() in i["channel_name"].lower() and i["status"] == "open"
-        ][:25]
+        ][:DISCORD_AUTOCOMPLETE_MAX_ENTRIES]
 
     @invitational_renew.autocomplete("short_name")
     async def short_name_renew_autocomplete(
@@ -787,7 +788,7 @@ class StaffInvitational(commands.Cog):
             for i in invitationals
             if current.lower() in i["channel_name"].lower()
             and i["status"] == "archived"
-        ][:25]
+        ][:DISCORD_AUTOCOMPLETE_MAX_ENTRIES]
 
 
 async def setup(bot: PiBot):

--- a/src/discord/welcome.py
+++ b/src/discord/welcome.py
@@ -129,7 +129,7 @@ class Chooser(discord.ui.View):
             ProfileMessage,
         ],
         update_values: Callable[[discord.Member, str, list[RoleItem]], None],
-        count: int = 25,
+        count: int = src.discord.globals.DISCORD_AUTOCOMPLETE_MAX_ENTRIES,
         placeholder: str | None = None,
     ):
         super().__init__()


### PR DESCRIPTION
# Description
Removes magic number in favor of global constant. If there is ever a day Discord decides to increase (or decrease) the number of autocompletion entries, we shall rest easy now.

# Checks

- [x] I ran `black` over the code to ensure formatting.
- [ ] I added docstrings to **any** new modules, classes, and methods.
- [ ] I updated the docstrings of **any** updated modules, classes, and methods.
- [ ] I added/updated Python typings for any new/updated class and module.
- [ ] I updated the bot version (if necessary).
- [ ] I ran mypy and reviewed any shown errors related to my changes.

# Important Info

- [ ] This pull request adds new `pip` dependencies.
- [ ] This pull request adds new external dependencies.
- [ ] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:
- N/A

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
