### PR TITLE
Fix `/censor remove` response to edit the original message

### DIFF
--- a/src/discord/staff/censor.py
+++ b/src/discord/staff/censor.py
@@ -113,7 +113,7 @@ class StaffCensor(commands.Cog):
 
         if censor_type == "word":
             if phrase not in src.discord.globals.CENSOR["words"]:
-                await interaction.response.send_message(
+                await interaction.edit_original_response(
                     content=f"`{phrase}` is not in the list of censored words.",
                 )
             else:
@@ -129,7 +129,7 @@ class StaffCensor(commands.Cog):
                 )
         elif censor_type == "emoji":
             if phrase not in src.discord.globals.CENSOR["emojis"]:
-                await interaction.response.send_message(
+                await interaction.edit_original_response(
                     content=f"{phrase} is not in the list of censored emojis.",
                 )
             else:


### PR DESCRIPTION
# Description
The response for `/censor remove` either would edit the original response or send a new message. This fixes the inconsistency by making all responses edit the original message.

# Checks

- [x] I ran `black` over the code to ensure formatting.
- [ ] I added docstrings to **any** new modules, classes, and methods.
- [ ] I updated the docstrings of **any** updated modules, classes, and methods.
- [ ] I added/updated Python typings for any new/updated class and module.
- [ ] I updated the bot version (if necessary).
- [ ] I ran mypy and reviewed any shown errors related to my changes.

# Important Info

- [ ] This pull request adds new `pip` dependencies.
- [ ] This pull request adds new external dependencies.
- [ ] This pull request changes the required versions of some dependencies.

# Issues Closed
My pull request closes the following issues:
- N/A

# Thank You
Thank you for your contribution to Scioly.org! This pull request will be reviewed
in a promptly manner. If not done, please feel free to contact @cbrxyz.
